### PR TITLE
投币任务执行前，判断用户等级，6级大佬不再进行投币

### DIFF
--- a/src/Ray.BiliBiliTool.Application/DailyTaskAppService.cs
+++ b/src/Ray.BiliBiliTool.Application/DailyTaskAppService.cs
@@ -63,7 +63,7 @@ namespace Ray.BiliBiliTool.Application
             UserInfo userInfo = Login();
             DailyTaskInfo dailyTaskInfo = GetDailyTaskStatus();
             WatchAndShareVideo(dailyTaskInfo);
-            AddCoinsForVideo();
+            AddCoinsForVideo(userInfo);
 
             //签到：
             LiveSign();
@@ -122,9 +122,9 @@ namespace Ray.BiliBiliTool.Application
         /// 投币任务
         /// </summary>
         [TaskInterceptor("投币", rethrowWhenException: false)]
-        private void AddCoinsForVideo()
+        private void AddCoinsForVideo(UserInfo userInfo)
         {
-            _donateCoinDomainService.AddCoinsForVideos();
+            _donateCoinDomainService.AddCoinsForVideos(userInfo);
         }
 
         /// <summary>

--- a/src/Ray.BiliBiliTool.DomainService/DonateCoinDomainService.cs
+++ b/src/Ray.BiliBiliTool.DomainService/DonateCoinDomainService.cs
@@ -69,8 +69,13 @@ namespace Ray.BiliBiliTool.DomainService
         /// <summary>
         /// 完成投币任务
         /// </summary>
-        public void AddCoinsForVideos()
+        public void AddCoinsForVideos(UserInfo userInfo)
         {
+            if(userInfo.Level_info.Current_level >= 6)
+            {
+                _logger.LogInformation("【投币】 : 你已经是6级大佬了，不需要投币");
+                return;
+            }
             int needCoins = GetNeedDonateCoinNum();
             if (needCoins <= 0) return;
 

--- a/src/Ray.BiliBiliTool.DomainService/Interfaces/IDonateCoinDomainService.cs
+++ b/src/Ray.BiliBiliTool.DomainService/Interfaces/IDonateCoinDomainService.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Ray.BiliBiliTool.Agent.BiliBiliAgent.Dtos;
+using System;
 using System.Collections.Generic;
 using System.Text;
 
@@ -9,7 +10,7 @@ namespace Ray.BiliBiliTool.DomainService.Interfaces
     /// </summary>
     public interface IDonateCoinDomainService : IDomainService
     {
-        void AddCoinsForVideos();
+        void AddCoinsForVideos(UserInfo userInfo);
 
         Tuple<string, string> TryGetCanDonatedVideo();
 


### PR DESCRIPTION
feat: #issue207 投币任务执行前，判断用户等级，6级大佬不再进行投币

<!-- 该操作会向作者源仓库发起PR，是用来向源仓库贡献自己代码的 -->
<!-- 请PR到我的develop分支上，main分支不接受直接PR -->

<!-- 如果您明白正在做什么，请将下一行中符号【】内的文字由“no”修改为“yes”（不含引号） -->
<!-- 请问您是否明白：【yes】 -->

【内容】：
fix: issue #207  投币任务执行前，判断用户等级，6级大佬不再进行投币

修改issue https://github.com/RayWangQvQ/BiliBiliToolPro/issues/207 提到的问题，在执行投币任务前判断用户等级，6级直接略过投币任务
