### PR TITLE
fix: cron.env

### DIFF
--- a/docker/entry.sh
+++ b/docker/entry.sh
@@ -8,7 +8,8 @@ declare -p | grep -v "no_proxy" > /etc/cron.env
 echo "=>完成"
 
 echo "[step 2/4]配置cron定时任务"
-echo "BASH_ENV=/etc/cron.env" > /etc/cron.d/bilicron
+echo "SHELL=/bin/bash" > /etc/cron.d/bilicron
+echo "BASH_ENV=/etc/cron.env" >> /etc/cron.d/bilicron
 if [ -z "$Ray_DailyTaskConfig__Cron$Ray_LiveLotteryTaskConfig__Cron$Ray_UnfollowBatchedTaskConfig__Cron$Ray_VipBigPointConfig__Cron" ]; then
 	echo "=>使用默认的定时任务配置"
 	cat /app/crontab >> /etc/cron.d/bilicron
@@ -35,7 +36,8 @@ touch /var/log/cron.log
 
 if ! [ -z "$Ray_Crontab" ]; then
 	echo "=>检测到自定义定时任务"
-	echo "BASH_ENV=/etc/cron.env" > /etc/cron.d/customcron
+	echo "SHELL=/bin/bash" > /etc/cron.d/customcron
+	echo "BASH_ENV=/etc/cron.env" >> /etc/cron.d/customcron
 	echo "$Ray_Crontab" >> /etc/cron.d/customcron
 
 	cat /etc/cron.d/customcron


### PR DESCRIPTION
<!-- 该操作会向作者源仓库发起PR，是用来向源仓库贡献自己代码的 -->
<!-- 请PR到我的develop分支上，main分支不接受直接PR -->

<!-- 如果您明白正在做什么，请将下一行中符号【】内的文字由“no”修改为“yes”（不含引号） -->
<!-- 请问您是否明白：【yes】 -->

【内容】：
请描述您将贡献的内容

cron 的默认运行环境是 `sh`，因此若不设置 `SHELL=/bin/bash` 会导致 `BASH_ENV` 不生效