### PR TITLE
Init Chart support

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: bilibili-tool
+description: A Helm chart for running bilibili tool in Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "0.2.1"

--- a/helm/README.md
+++ b/helm/README.md
@@ -1,0 +1,47 @@
+# Chart 使用说明
+<!-- TOC depthFrom:2 -->
+
+- [1. 前期工作](#1-前期工作)
+    - [1.1. 环境准备](#11-环境准备)
+- [2. 方式：Chart 安装](#2-方式-Chart安装)
+    - [2.1. 启动](#21-启动)
+
+<!-- /TOC -->
+## 1. 前期工作
+
+### 1.1. 环境准备
+
+请确认已安装了Kubernetes所需环境（[Kubernetes](https://kubernetes/kubernetes.io))
+
+请确认已具有了健康运行的Kubernetes集群，或者也可以使用kind([kind](https://kind.sigs.k8s.io/))来本地运行
+
+请确认已安装了Helm工具([Helm](https://helm.sh/))
+
+## 2. 方式：Chart 安装
+
+### 2.1. 启动
+
+```
+# 进入目录
+cd helm
+
+# 修改Chart values文件
+
+修改values.yaml，填写env下cookie以及定时触发cron表达式，其他的环境变量设置可以按需设置
+
+helm install <your_release_name> .
+
+如果您想先检查一下生成的资源文件以及是否可以部署在集群中
+
+helm install <your_release_name> . --dry-run > workload.yaml
+
+kubectl apply -f workload.yaml --dry-run=server
+
+确认无误后
+
+helm install <your_release_name> .
+
+# 查看启动日志
+kubectl logs <your-bilibilitool-pod-name> -f
+```
+

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "bilibili_tool.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "bilibili_tool.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "bilibili_tool.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "bilibili_tool.labels" -}}
+helm.sh/chart: {{ include "bilibili_tool.chart" . }}
+{{ include "bilibili_tool.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "bilibili_tool.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "bilibili_tool.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "bilibili_tool.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "bilibili_tool.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -1,0 +1,54 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "bilibili_tool.fullname" . }}
+  labels:
+    {{- include "bilibili_tool.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "bilibili_tool.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "bilibili_tool.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- if .Values.volumes.enabled }}
+      volumes:
+      - name: {{ .Values.volumes.name }}
+        hostPath: 
+          path: {{ .Values.volumes.path }}
+      {{- end }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            {{- toYaml .Values.env | nindent 12 }}
+          {{- if .Values.volumes.enabled }}
+          volumeMounts:
+          - mountPath: "/bilibili_tool/Logs"
+            name: {{ .Values.volumes.name }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1,0 +1,62 @@
+# Default values for bilibili_tool.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: zai7lou/bilibili_tool_pro
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: "0.2.1"
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+env:
+  # cookie - required
+  - name: Ray_BiliBiliCookies__1
+    # past your cookie value
+    value: ""
+  # DailyTrigger - required
+  - name: Ray_DailyTaskConfig__Cron
+    value: "10 8 * * *"
+  
+  # Optional fields
+  - name: Ray_Security__IntervalSecondsBetweenRequestApi
+    value: "20"
+  - name: Ray_Security__RandomSleepMaxMin
+    value: "20"
+  #- name: Ray_LiveLotteryTaskConfig__Cron
+  #  value: ""
+  #- name: Ray_UnfollowBatchedTaskConfig__Cron
+  #  value: ""
+  #- name: Ray_VipBigPointConfig__Cron
+  #  value: ""
+
+volumes:
+  enabled: false
+  # if `enabled=true`, then path and name is required
+  path: "/tmp/Logs"
+  name: "bili-tool-vol"
+
+podAnnotations: {}
+
+resources:
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  limits:
+    cpu: 100m
+    memory: 180Mi
+  requests:
+    cpu: 100m
+    memory: 180Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}


### PR DESCRIPTION
<!-- 该操作会向作者源仓库发起PR，是用来向源仓库贡献自己代码的 -->
<!-- 请PR到我的develop分支上，main分支不接受直接PR -->

<!-- 如果您明白正在做什么，请将下一行中符号【】内的文字由“no”修改为“yes”（不含引号） -->
<!-- 请问您是否明白：【yes】 -->

【内容】：
请描述您将贡献的内容
Init a simple Chart for BiliBiliTool. 
Just to make sure this tool can get more platforms to run on. 
Nothing new, just a wrapper for bilibilitool image and maybe not that necessary

用户只需要改动values中的cookie以及cron表达式既可以定时触发，其他的环境变量定义也可以指定

只是一个很简单的版本，仅仅确保了可以成功运行起来。

Test: 现在只是在kind cluster上做了简单的部署，确认已经运行