### PR TITLE
通过扫码自动更新第一个cookie

### DIFF
--- a/qinglong/DefaultTasks/bili_task_get_cookie.py
+++ b/qinglong/DefaultTasks/bili_task_get_cookie.py
@@ -1,0 +1,87 @@
+'''
+1 9 11 11 1 bili_task_get_cookie.py
+手动运行，查看日志，并使用手机B站app扫描日志中二维码，注意，只能修改第一个cookie
+如果产生错误，重新运行并用手机扫描二维码
+有可能识别不出来二维码，我测试了几次都能识别
+
+默认环境变量存放位置为/ql/data/config/env.sh
+可以自己通过docker命令进入容器查找这个文件位置。docker exec -it qinglong /bin/bash,进入青龙容器，然后查找一下这个文件位置
+filename = '../config/env.sh'
+'''
+
+import qrcode
+import requests
+import json
+import time
+import os
+
+filename = '/ql/data/config/env.sh'
+
+url_get = 'http://passport.bilibili.com/x/passport-login/web/qrcode/generate'
+headers = {
+    "user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/108.0.0.0 Safari/537.36 Edg/108.0.1462.42"
+    }
+session = requests.session()
+response = session.get(url_get, headers=headers)
+json_data = json.loads(response.text)
+qr_data = json_data['data']['url']
+qr_code = json_data['data']['qrcode_key']
+# print(qr_data)
+#  img = qrcode.make(qr_data)
+#  img.save('../upload/B.png')
+# 生成二维码，并且打印，只有invert是True手机才能识别，默认的打印识别不出来
+qr = qrcode.QRCode()
+qr.add_data(qr_data)
+qr.print_ascii(invert=True)
+
+url_get_2 = f'http://passport.bilibili.com/x/passport-login/web/qrcode/poll?qrcode_key={qr_code}&source=main_mini'
+refresh_token = ''
+# 尝试次数
+try_time = 8
+while True:
+    try_time -= 1
+    if not try_time:
+        print('一直没有扫码，退出登录！')
+        exit(1)
+    response = session.get(url_get_2, headers=headers)
+    json_data = json.loads(response.text)
+    response_data_2 = json_data['data']
+    if response_data_2['code'] == 0:
+        try_time += 5
+        refresh_token = response_data_2['refresh_token']
+        print(response_data_2, end='')
+    if response_data_2['message'] == '二维码已失效':
+        print(response_data_2['message'])
+        print('-' * 20)
+        break
+    print(response_data_2['message'])
+    print('-' * 20)
+    time.sleep(5)
+session.get('https://api.bilibili.com/x/web-interface/nav')
+cookies = requests.utils.dict_from_cookiejar(session.cookies)
+lst = []
+for item in cookies.items():
+    lst.append(f"{item[0]}={item[1]}")
+
+cookie_str = ';'.join(lst)
+print('=' * 20)
+print(cookie_str)
+print('=' * 20)
+# 修改环境变量
+with open(filename, 'r') as f:
+    lines = f.readlines()
+
+flag = True
+with open(filename, 'w') as f:
+    for l in lines:
+        if 'Ray_BiliBiliCookies__1' in l:
+            flag = False
+            l = f'export Ray_BiliBiliCookies__1="{cookie_str}"\n'
+            print(l)
+        f.write(l)
+    if flag:
+        flag = False
+        l = f'export Ray_BiliBiliCookies__1="{cookie_str}"\n'
+        print(l)
+        f.write(l)
+os.popen(f'source {filename}')

--- a/qinglong/extra.sh
+++ b/qinglong/extra.sh
@@ -5,4 +5,6 @@
 # 安装 dotnet 环境
 # curl -sSL https://ghproxy.com/https://raw.githubusercontent.com/RayWangQvQ/BiliBiliToolPro/main/qinglong/ray-dotnet-install.sh | bash /dev/stdin --no-official
 curl -sSL https://ghproxy.com/https://raw.githubusercontent.com/RayWangQvQ/BiliBiliToolPro/main/qinglong/ray-dotnet-install.sh | bash /dev/stdin
+# 安装需要用到的包
+pip3 install requests qrcode pillow
 # 其他代码...


### PR DESCRIPTION
<!-- 该操作会向作者源仓库发起PR，是用来向源仓库贡献自己代码的 -->
<!-- 请PR到我的develop分支上，main分支不接受直接PR -->

<!-- 如果您明白正在做什么，请将下一行中符号【】内的文字由“no”修改为“yes”（不含引号） -->
<!-- 请问您是否明白：【yes】 -->

【内容】：
将B站登录二维码打印到日志文件中，通过手机B站app扫描二维码，自动更新第一个Cookie。需要安装第三方python包，`qrcode`, `requests`, `pillow`.


在`青龙面板`中运行脚本`bili_task_get_cookie.py`，B站登录二维码会被打印在日志中，用手机Bilibili的app扫描二维码（有时候会识别不出来，不过我没遇到），自动更新第一个B站的Cookie到环境变量中（不过面板中的数值没变）。

我自己现在就是这样更新Cookie，感觉上比手动去找方便一点。（前提是比较习惯使用手机扫码）

**会有运行失败的情况，重新运行并扫码就行。**

运行成功后（且扫码）日志信息如下：
![微信截图_20221208152742](https://user-images.githubusercontent.com/20317612/206385551-f3f35bd0-ba4e-4dff-b52b-70d84627efdf.png)
![微信截图_20221208152904](https://user-images.githubusercontent.com/20317612/206385566-adc870a5-f3f3-4c04-8b0e-2c4dda6f6b5a.png)

