### PR TITLE
修复由于wbi鉴权导致的LiveFansMedal功能出现的错误

### DIFF
--- a/src/Ray.BiliBiliTool.Agent/BiliBiliAgent/Dtos/GetSpaceInfoFullDto.cs
+++ b/src/Ray.BiliBiliTool.Agent/BiliBiliAgent/Dtos/GetSpaceInfoFullDto.cs
@@ -1,0 +1,12 @@
+﻿namespace Ray.BiliBiliTool.Agent.BiliBiliAgent.Dtos;
+
+public class GetSpaceInfoDto
+{
+    public long mid { get; set; }
+}
+public class GetSpaceInfoFullDto : GetSpaceInfoDto
+{
+    public string w_rid { get; set; } 
+
+    public long wts { get; set; } 
+}

--- a/src/Ray.BiliBiliTool.Agent/BiliBiliAgent/Interfaces/IUserInfoApi.cs
+++ b/src/Ray.BiliBiliTool.Agent/BiliBiliAgent/Interfaces/IUserInfoApi.cs
@@ -26,7 +26,7 @@ namespace Ray.BiliBiliTool.Agent.BiliBiliAgent.Interfaces
         /// </summary>
         /// <param name="userId">uid</param>
         /// <returns></returns>
-        [HttpGet("/x/space/wbi/acc/info?mid={userId}")]
-        Task<BiliApiResponse<GetSpaceInfoResponse>> GetSpaceInfo(long userId);
+        [HttpGet("/x/space/wbi/acc/info")]
+        Task<BiliApiResponse<GetSpaceInfoResponse>> GetSpaceInfo([PathQuery] GetSpaceInfoFullDto request);
     }
 }

--- a/src/Ray.BiliBiliTool.DomainService/LiveDomainService.cs
+++ b/src/Ray.BiliBiliTool.DomainService/LiveDomainService.cs
@@ -33,7 +33,7 @@ namespace Ray.BiliBiliTool.DomainService
         private readonly DailyTaskOptions _dailyTaskOptions;
         private readonly SecurityOptions _securityOptions;
         private readonly BiliCookie _biliCookie;
-
+        private readonly IWbiDomainService _wbiDomainService;
 
         public LiveDomainService(ILogger<LiveDomainService> logger,
             ILiveApi liveApi,
@@ -44,6 +44,7 @@ namespace Ray.BiliBiliTool.DomainService
             IOptionsMonitor<LiveLotteryTaskOptions> liveLotteryTaskOptions,
             IOptionsMonitor<LiveFansMedalTaskOptions> liveFansMedalTaskOptions,
             IOptionsMonitor<SecurityOptions> securityOptions,
+            IWbiDomainService wbiDomainService,
             BiliCookie biliCookie)
         {
             _logger = logger;
@@ -55,6 +56,7 @@ namespace Ray.BiliBiliTool.DomainService
             _dailyTaskOptions = dailyTaskOptions.CurrentValue;
             _liveFansMedalTaskOptions = liveFansMedalTaskOptions.CurrentValue;
             _securityOptions = securityOptions.CurrentValue;
+            _wbiDomainService = wbiDomainService;
             _biliCookie = biliCookie;
 
         }
@@ -407,7 +409,20 @@ namespace Ray.BiliBiliTool.DomainService
 
                 // 通过空间主页信息获取直播间 id
                 var liveHostUserId = medal.Medal_info.Target_id;
-                var spaceInfo = await _userInfoApi.GetSpaceInfo(liveHostUserId);
+                var req = new GetSpaceInfoDto()
+                {
+                    mid = liveHostUserId
+                };
+
+
+                var w_ridDto = await _wbiDomainService.GetWridAsync(req);
+                var fullDto = new GetSpaceInfoFullDto()
+                {
+                    mid = liveHostUserId,
+                    w_rid = w_ridDto.w_rid,
+                    wts = w_ridDto.wts
+                };
+                var spaceInfo = await _userInfoApi.GetSpaceInfo(fullDto);
                 if (spaceInfo.Code != 0)
                 {
                     _logger.LogError("【获取直播间信息】失败");
@@ -578,7 +593,20 @@ namespace Ray.BiliBiliTool.DomainService
 
                 // 通过空间主页信息获取直播间 id
                 var liveHostUserId = medal.Medal_info.Target_id;
-                var spaceInfo = await _userInfoApi.GetSpaceInfo(liveHostUserId);
+                var req = new GetSpaceInfoDto()
+                {
+                    mid = liveHostUserId
+                };
+
+
+                var w_ridDto = await _wbiDomainService.GetWridAsync(req);
+                var fullDto = new GetSpaceInfoFullDto()
+                {
+                    mid = liveHostUserId,
+                    w_rid = w_ridDto.w_rid,
+                    wts = w_ridDto.wts
+                };
+                var spaceInfo = await _userInfoApi.GetSpaceInfo(fullDto);
                 if (spaceInfo.Code != 0)
                 {
                     _logger.LogError("【获取空间信息】失败");

--- a/test/BiliAgentTest/LiveApiTest.cs
+++ b/test/BiliAgentTest/LiveApiTest.cs
@@ -10,6 +10,7 @@ using System.Diagnostics;
 using System.Threading.Tasks;
 using Ray.BiliBiliTool.Infrastructure.Cookie;
 using Xunit;
+using Ray.BiliBiliTool.DomainService.Interfaces;
 
 namespace BiliAgentTest
 {
@@ -123,7 +124,7 @@ namespace BiliAgentTest
         }
 
         [Fact]
-        public void GetSpaceInfo_Normal_Success()
+        public async Task GetSpaceInfo_Normal_Success()
         {
             using var scope = Global.ServiceProviderRoot.CreateScope();
 
@@ -131,7 +132,25 @@ namespace BiliAgentTest
             var api = scope.ServiceProvider.GetRequiredService<IUserInfoApi>();
             var biliCookie = scope.ServiceProvider.GetRequiredService<BiliCookie>();
 
-            BiliApiResponse<GetSpaceInfoResponse> re = api.GetSpaceInfo(919174).Result;
+            var domainService = scope.ServiceProvider.GetRequiredService<IWbiDomainService>();
+
+            var req = new GetSpaceInfoDto()
+            {
+                mid = 919174L
+            };
+
+            var w_ridDto = await domainService.GetWridAsync(req);
+
+            var fullDto = new GetSpaceInfoFullDto()
+            {
+                mid = 919174L,
+                w_rid = w_ridDto.w_rid,
+                wts = w_ridDto.wts
+            };
+
+
+
+            BiliApiResponse<GetSpaceInfoResponse> re = api.GetSpaceInfo(fullDto).Result;
 
             Assert.True(re.Code == 0);
             Assert.NotNull(re.Data);


### PR DESCRIPTION
<!-- 该操作会向作者源仓库发起PR，是用来向源仓库贡献自己代码的 -->
<!-- 请PR到我的develop分支上，main分支不接受直接PR -->

<!-- 如果您明白正在做什么，请将下一行中符号【】内的文字由“no”修改为“yes”（不含引号） -->
<!-- 请问您是否明白：【yes】 -->

【内容】：
修复在 https://github.com/RayWangQvQ/BiliBiliToolPro/issues/543 中由于wbi鉴权导致的`LiveFansMedal`功能错误的问题
同时修改的`LiveApiTest`单元测试中的`GetSpaceInfo_Normal_Success()`使其能测试wbi鉴权的api
所有修改基本依照v2.0.0中对wbi鉴权的修改
![图片1](https://github.com/RayWangQvQ/BiliBiliToolPro/assets/63545780/ef6d1d4b-f1a1-41a5-9a6c-f36a1d18457f)
