### PR TITLE
feat: add CustomComicId and CustomEpId

### DIFF
--- a/src/Ray.BiliBiliTool.Agent/BiliBiliAgent/Interfaces/IMangaApi.cs
+++ b/src/Ray.BiliBiliTool.Agent/BiliBiliAgent/Interfaces/IMangaApi.cs
@@ -26,8 +26,8 @@ namespace Ray.BiliBiliTool.Agent.BiliBiliAgent.Interfaces
         /// </summary>
         /// <param name="platform"></param>
         /// <returns></returns>
-        [HttpPost("/twirp/bookshelf.v1.Bookshelf/AddHistory?platform={platform}&comic_id=27355&ep_id=381662")]
-        Task<BiliApiResponse> ReadManga(string platform);
+        [HttpPost("/twirp/bookshelf.v1.Bookshelf/AddHistory?platform={platform}&comic_id={comic_id}&ep_id={ep_id}")]
+        Task<BiliApiResponse> ReadManga(string platform, int comic_id, int ep_id);
 
         /// <summary>
         /// 获取会员漫画奖励

--- a/src/Ray.BiliBiliTool.Agent/BiliBiliAgent/Interfaces/IMangaApi.cs
+++ b/src/Ray.BiliBiliTool.Agent/BiliBiliAgent/Interfaces/IMangaApi.cs
@@ -27,7 +27,7 @@ namespace Ray.BiliBiliTool.Agent.BiliBiliAgent.Interfaces
         /// <param name="platform"></param>
         /// <returns></returns>
         [HttpPost("/twirp/bookshelf.v1.Bookshelf/AddHistory?platform={platform}&comic_id={comic_id}&ep_id={ep_id}")]
-        Task<BiliApiResponse> ReadManga(string platform, int comic_id, int ep_id);
+        Task<BiliApiResponse> ReadManga(string platform, long comic_id, long ep_id);
 
         /// <summary>
         /// 获取会员漫画奖励

--- a/src/Ray.BiliBiliTool.Config/Options/DailyTaskOptions.cs
+++ b/src/Ray.BiliBiliTool.Config/Options/DailyTaskOptions.cs
@@ -77,6 +77,15 @@ namespace Ray.BiliBiliTool.Config.Options
         /// </summary>
         public string DevicePlatform { get; set; } = "android";
 
+        /// <summary>
+        /// 自定义漫画阅读 comic_id
+        /// </summary>
+        public int CustomComicId { get; set; } = 27355;
+
+        /// <summary>
+        /// 自定义漫画阅读 ep_id
+        /// </summary>
+        public int CustomEpId { get; set; } = 381662;
 
         public List<long> SupportUpIdList
         {

--- a/src/Ray.BiliBiliTool.Config/Options/DailyTaskOptions.cs
+++ b/src/Ray.BiliBiliTool.Config/Options/DailyTaskOptions.cs
@@ -80,12 +80,12 @@ namespace Ray.BiliBiliTool.Config.Options
         /// <summary>
         /// 自定义漫画阅读 comic_id
         /// </summary>
-        public int CustomComicId { get; set; } = 27355;
+        public long CustomComicId { get; set; } = 27355;
 
         /// <summary>
         /// 自定义漫画阅读 ep_id
         /// </summary>
-        public int CustomEpId { get; set; } = 381662;
+        public long CustomEpId { get; set; } = 381662;
 
         public List<long> SupportUpIdList
         {

--- a/src/Ray.BiliBiliTool.Console/appsettings.json
+++ b/src/Ray.BiliBiliTool.Console/appsettings.json
@@ -16,8 +16,8 @@
     "DayOfReceiveVipPrivilege": 1, //每月几号自动领取会员权益的[-1,31]，-1表示不指定，默认每月1号；0表示不自动领取
     "DayOfExchangeSilver2Coin": 0, //每月几号执行银瓜子兑换硬币[-1,31]，-1表示不指定，默认每月最后一天；-2表示每天；0表示不进行兑换
     "DevicePlatform": "android", //执行客户端操作时的平台 [ios,android]
-    "CustomComicId": "27355", //自定义漫画阅读 comic_id，若不清楚含义请勿修改
-    "CustomEpId": "381662" //自定义漫画阅读 ep_id，若不清楚含义请勿修改
+    "CustomComicId": 27355, //自定义漫画阅读 comic_id，若不清楚含义请勿修改
+    "CustomEpId": 381662 //自定义漫画阅读 ep_id，若不清楚含义请勿修改
   },
 
   "LiveLotteryTaskConfig": {

--- a/src/Ray.BiliBiliTool.Console/appsettings.json
+++ b/src/Ray.BiliBiliTool.Console/appsettings.json
@@ -15,7 +15,9 @@
     "ChargeComment": "", //充电后留言
     "DayOfReceiveVipPrivilege": 1, //每月几号自动领取会员权益的[-1,31]，-1表示不指定，默认每月1号；0表示不自动领取
     "DayOfExchangeSilver2Coin": 0, //每月几号执行银瓜子兑换硬币[-1,31]，-1表示不指定，默认每月最后一天；-2表示每天；0表示不进行兑换
-    "DevicePlatform": "android" //执行客户端操作时的平台 [ios,android]
+    "DevicePlatform": "android", //执行客户端操作时的平台 [ios,android]
+    "CustomComicId": "27355", //自定义漫画阅读 comic_id，若不清楚含义请勿修改
+    "CustomEpId": "381662" //自定义漫画阅读 ep_id，若不清楚含义请勿修改
   },
 
   "LiveLotteryTaskConfig": {

--- a/src/Ray.BiliBiliTool.DomainService/MangaDomainService.cs
+++ b/src/Ray.BiliBiliTool.DomainService/MangaDomainService.cs
@@ -62,6 +62,7 @@ namespace Ray.BiliBiliTool.DomainService
         /// </summary>
         public async Task MangaRead()
         {
+            if ( _dailyTaskOptions.CustomComicId <= 0 ) return;
             BiliApiResponse response = await _mangaApi.ReadManga(_dailyTaskOptions.DevicePlatform, _dailyTaskOptions.CustomComicId, _dailyTaskOptions.CustomEpId);
 
             if (response.Code == 0)

--- a/src/Ray.BiliBiliTool.DomainService/MangaDomainService.cs
+++ b/src/Ray.BiliBiliTool.DomainService/MangaDomainService.cs
@@ -62,11 +62,11 @@ namespace Ray.BiliBiliTool.DomainService
         /// </summary>
         public async Task MangaRead()
         {
-            BiliApiResponse response = await _mangaApi.ReadManga(_dailyTaskOptions.DevicePlatform);
+            BiliApiResponse response = await _mangaApi.ReadManga(_dailyTaskOptions.DevicePlatform, _dailyTaskOptions.CustomComicId, _dailyTaskOptions.CustomEpId);
 
             if (response.Code == 0)
             {
-                _logger.LogInformation("【漫画阅读】成功, 阅读漫画为：堀与宫村");
+                _logger.LogInformation("【漫画阅读】成功");
             }
             else
             {


### PR DESCRIPTION
<!-- 该操作会向作者源仓库发起PR，是用来向源仓库贡献自己代码的 -->
<!-- 请PR到我的develop分支上，main分支不接受直接PR -->

<!-- 如果您明白正在做什么，请将下一行中符号【】内的文字由“no”修改为“yes”（不含引号） -->
<!-- 请问您是否明白：【yes】 -->

Allows user to customise comics and page numbers read by comic reading task.
No need to know which comic was read, so instead of getting it, just remove from log. It can be done again if an issue calls for it.
Allow edits by maintainers.