### PR TITLE
更改升级时间计算步骤

### DIFF
--- a/src/Ray.BiliBiliTool.Config/Constants.cs
+++ b/src/Ray.BiliBiliTool.Config/Constants.cs
@@ -17,6 +17,11 @@ namespace Ray.BiliBiliTool.Config
         public static int EveryDayExp = 65;
 
         /// <summary>
+        /// 每日获取的最少经验值
+        /// </summary>
+        public static int EveryDayMinExp = 25;
+
+        /// <summary>
         /// 开源地址
         /// </summary>
         public static string SourceCodeUrl = "https://github.com/RayWangQvQ/BiliBiliToolPro";


### PR DESCRIPTION
<!-- 该操作会向作者源仓库发起PR，是用来向源仓库贡献自己代码的 -->
<!-- 请PR到我的develop分支上，main分支不接受直接PR -->

<!-- 如果您明白正在做什么，请将下一行中符号【】内的文字由“no”修改为“yes”（不含引号） -->
<!-- 请问您是否明白：【yes】 -->

当可投硬币数量不足时（小于5枚时）将升级时间计算由每日 65 点经验，转为每日获取 25 点经验。使其更加贴合普通阿B用户的使用实际。

测试画面：
![image](https://github.com/RayWangQvQ/BiliBiliToolPro/assets/63545780/22677a6f-ff68-44d2-8402-eddd980b6f03)


