### PR TITLE
基本完成升级时间计算的升级，并增加一个单元测试

### DIFF
--- a/src/Ray.BiliBiliTool.DomainService/AccountDomainService.cs
+++ b/src/Ray.BiliBiliTool.DomainService/AccountDomainService.cs
@@ -68,7 +68,7 @@ namespace Ray.BiliBiliTool.DomainService
 
             if (useInfo.Level_info.Current_level < 6)
             {
-                _logger.LogInformation("【距升级Lv{0}】{1}天",
+                _logger.LogInformation("【距升级Lv{0}】预计{1}天",
                     useInfo.Level_info.Current_level + 1,
                     CalculateUpgradeTime(useInfo));
             }

--- a/src/Ray.BiliBiliTool.DomainService/AccountDomainService.cs
+++ b/src/Ray.BiliBiliTool.DomainService/AccountDomainService.cs
@@ -25,6 +25,7 @@ namespace Ray.BiliBiliTool.DomainService
         private readonly IRelationApi _relationApi;
         private readonly UnfollowBatchedTaskOptions _unfollowBatchedTaskOptions;
         private readonly BiliCookie _cookie;
+        private readonly DailyTaskOptions _dailyTaskOptions;
 
         public AccountDomainService(
             ILogger<AccountDomainService> logger,
@@ -32,14 +33,15 @@ namespace Ray.BiliBiliTool.DomainService
             BiliCookie cookie,
             IUserInfoApi userInfoApi,
             IRelationApi relationApi,
-            IOptionsMonitor<UnfollowBatchedTaskOptions> unfollowBatchedTaskOptions
-        )
+            IOptionsMonitor<UnfollowBatchedTaskOptions> unfollowBatchedTaskOptions,
+            IOptionsMonitor<DailyTaskOptions> dailyTaskOptions)
         {
             _logger = logger;
             _dailyTaskApi = dailyTaskApi;
             _cookie = cookie;
             _userInfoApi = userInfoApi;
             _relationApi = relationApi;
+            _dailyTaskOptions = dailyTaskOptions.CurrentValue;
             _unfollowBatchedTaskOptions = unfollowBatchedTaskOptions.CurrentValue;
         }
 
@@ -66,9 +68,9 @@ namespace Ray.BiliBiliTool.DomainService
 
             if (useInfo.Level_info.Current_level < 6)
             {
-                _logger.LogInformation("【距升级Lv{0}】{1}天（如每日做满65点经验）",
+                _logger.LogInformation("【距升级Lv{0}】{1}天",
                     useInfo.Level_info.Current_level + 1,
-                    (useInfo.Level_info.GetNext_expLong() - useInfo.Level_info.Current_exp) / Constants.EveryDayExp);
+                    CalculateUpgradeTime(useInfo));
             }
             else
             {
@@ -216,5 +218,42 @@ namespace Ray.BiliBiliTool.DomainService
             TagDto tag = tagList.FirstOrDefault(x => x.Name == groupName);
             return tag;
         }
+
+        /// <summary>
+        /// 计算升级时间
+        /// </summary>
+        /// <param name="useInfo"></param>
+        /// <returns>升级时间</returns>
+        public int CalculateUpgradeTime(UserInfo useInfo)
+        {
+            double availableCoins = decimal.ToDouble(useInfo.Money ?? 0) - _dailyTaskOptions.NumberOfProtectedCoins;
+            long needExp = useInfo.Level_info.GetNext_expLong() - useInfo.Level_info.Current_exp;
+            int needDay;
+
+            if (availableCoins < 0)
+                needDay = (int)((double)needExp / 25 + _dailyTaskOptions.NumberOfProtectedCoins - Math.Abs(availableCoins));
+
+            switch (_dailyTaskOptions.NumberOfCoins)
+            {
+                case 0:
+                    needDay = (int)(needExp / 15);
+                    break;
+                case 1:
+                    needDay = (int)(needExp / 25);
+                    break;
+                default:
+                    int dailyExpAvailable = 15 + _dailyTaskOptions.NumberOfCoins * 10;
+                    double needFrontDay = availableCoins / (_dailyTaskOptions.NumberOfCoins - 1);
+
+                    if ((double)needExp / dailyExpAvailable > needFrontDay)
+                        needDay = (int)(needFrontDay + (needExp - dailyExpAvailable * needFrontDay) / 25);
+                    else
+                        needDay= (int)(needExp / dailyExpAvailable );
+                    break;
+            }
+
+            return needDay;
+        }
+
     }
 }

--- a/src/Ray.BiliBiliTool.DomainService/Interfaces/IAccountDomainService.cs
+++ b/src/Ray.BiliBiliTool.DomainService/Interfaces/IAccountDomainService.cs
@@ -24,5 +24,12 @@ namespace Ray.BiliBiliTool.DomainService.Interfaces
         /// 批量取关
         /// </summary>
         Task UnfollowBatched();
+
+        /// <summary>
+        /// 计算升级时间
+        /// </summary>
+        /// <param name="useInfo"></param>
+        /// <returns>升级时间</returns>
+        int CalculateUpgradeTime(UserInfo useInfo);
     }
 }

--- a/test/DomainServiceTest/CalculateUpgradeTimeTest.cs
+++ b/test/DomainServiceTest/CalculateUpgradeTimeTest.cs
@@ -1,0 +1,48 @@
+﻿using Ray.BiliBiliTool.Agent.BiliBiliAgent.Dtos;
+
+namespace DomainServiceTest;
+
+public class CalculateUpgradeTimeTest
+{
+    public CalculateUpgradeTimeTest()
+    {
+        Program.CreateHost(new[] { "--ENVIRONMENT=Development" });
+    }
+
+    [Fact]
+    public void TestCalculateUpgradeTime()
+    {
+        using var scope = Global.ServiceProviderRoot.CreateScope();
+        var accountDomainService = scope.ServiceProvider.GetRequiredService<IAccountDomainService>();
+        int needDay = accountDomainService.CalculateUpgradeTime(new UserInfo()
+        {
+            Money = 7,
+            Level_info = new LevelInfo()
+            {
+                Current_level = 5,
+                Current_exp = 100,
+                Next_exp = 200
+            }
+        });
+        int needDay2 = accountDomainService.CalculateUpgradeTime(new UserInfo()
+        {
+            Money = 7,
+            Level_info = new LevelInfo()
+            {
+                Current_level = 5,
+                Current_exp = 1000,
+                Next_exp = 2000
+            }
+        });
+
+        Assert.Equal(1,needDay);
+        Assert.Equal(37,needDay2);
+
+    }
+}
+
+
+
+
+
+


### PR DESCRIPTION
<!-- 该操作会向作者源仓库发起PR，是用来向源仓库贡献自己代码的 -->
<!-- 请PR到我的develop分支上，main分支不接受直接PR -->

<!-- 如果您明白正在做什么，请将下一行中符号【】内的文字由“no”修改为“yes”（不含引号） -->
<!-- 请问您是否明白：【yes】 -->

【内容】：

完成#583中提出的按当前进度计算升级时间，在@Initial-heart-1 与@XiaoYue-Kun 的帮助下，将之前实现的硬性计算25点经验值，改为更准确的计算方法（不考虑风纪委员，银瓜子兑换等硬币来源）

并在测试中增添一个专门的单元测试（使用需有cookie）来检测对应修改。（主要是方便调试）

**注：该算法的准确性仍需要验证，目前只是在小范围内进行了手工验证，还没有全覆盖测试**

附运行截图：
![00d4dfd01e0590e4207014730a0c10b](https://github.com/RayWangQvQ/BiliBiliToolPro/assets/63545780/17ec1151-df0d-4d54-b929-f027b321dd27)
