### PR TITLE
build: 构建时不生成调试符号

### DIFF
--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -62,10 +62,9 @@ publish_dotnet_dependent() {
     dotnet publish --configuration Release \
         --self-contained false \
         -p:PublishSingleFile=true \
+        -p:DebugType=None \
+        -p:DebugSymbols=false \
         -o $outputDir
-
-    echo "clear pdb files"
-    rm -rf $outputDir/*.pdb
 
     echo "zip files..."
     cd $publishDir
@@ -90,10 +89,9 @@ publish_self_contained() {
         --runtime $runtime \
         -p:PublishTrimmed=true \
         -p:PublishSingleFile=true \
+        -p:DebugType=None \
+        -p:DebugSymbols=false \
         -o $outputDir
-
-    echo "clear pdb files"
-    rm -rf $outputDir/*.pdb
 
     echo "zip files..."
     cd $publishDir


### PR DESCRIPTION
<!-- 该操作会向作者源仓库发起PR，是用来向源仓库贡献自己代码的 -->
<!-- 请PR到我的develop分支上，main分支不接受直接PR -->

<!-- 如果您明白正在做什么，请将下一行中符号【】内的文字由“no”修改为“yes”（不含引号） -->
<!-- 请问您是否明白：【yes】 -->

【内容】：
请描述您将贡献的内容


添加 dotnet 选项抑制 *.pdb 生成，从而无需手动删除文件。