### PR TITLE
跳过有粉丝牌而没有直播间的主播

### DIFF
--- a/src/Ray.BiliBiliTool.Agent/BiliBiliAgent/Dtos/Article/AddCoinForArticleRequest.cs
+++ b/src/Ray.BiliBiliTool.Agent/BiliBiliAgent/Dtos/Article/AddCoinForArticleRequest.cs
@@ -1,0 +1,22 @@
+﻿namespace Ray.BiliBiliTool.Agent.BiliBiliAgent.Dtos.Article;
+
+public class AddCoinForArticleRequest
+{
+    public AddCoinForArticleRequest(long cvid,long mid,string csrf)
+    {
+        Aid = cvid;
+        Upid = mid;
+        Csrf = csrf;
+    }
+
+    public long Aid { get; set; }
+
+    public long Upid { get; set; }
+
+    public int Multiply { get; set; } = 1;
+
+    // 必须为2
+    public int Avtype { get; private set; } = 2;
+
+    public string Csrf { get; set; }
+}

--- a/src/Ray.BiliBiliTool.Agent/BiliBiliAgent/Interfaces/IArticleApi.cs
+++ b/src/Ray.BiliBiliTool.Agent/BiliBiliAgent/Interfaces/IArticleApi.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Ray.BiliBiliTool.Agent.BiliBiliAgent.Dtos;
+using Ray.BiliBiliTool.Agent.BiliBiliAgent.Dtos.Article;
+using Ray.BiliBiliTool.Agent.BiliBiliAgent.Dtos.Video;
+using WebApiClientCore.Attributes;
+
+namespace Ray.BiliBiliTool.Agent.BiliBiliAgent.Interfaces
+{
+    
+    [Header("Host", "api.bilibili.com")]
+    public interface IArticleApi : IBiliBiliApi
+    {
+        [Header("Content-Type", "application/x-www-form-urlencoded")]
+        [Header("Origin", "https://www.bilibili.com")]
+        [HttpPost("/x/web-interface/coin/add")]
+        Task<BiliApiResponse> AddCoinForArticle([FormContent] AddCoinForArticleRequest request, [Header("referer")] string refer = "https://www.bilibili.com/read/cv5806746/?from=search&spm_id_from=333.337.0.0");
+
+    }
+
+    
+}

--- a/src/Ray.BiliBiliTool.Agent/Extensions/ServiceCollectionExtension.cs
+++ b/src/Ray.BiliBiliTool.Agent/Extensions/ServiceCollectionExtension.cs
@@ -73,6 +73,9 @@ namespace Ray.BiliBiliTool.Agent.Extensions
             services.AddBiliBiliClientApi<ILiveTraceApi>("https://live-trace.bilibili.com");
             services.AddBiliBiliClientApi<IHomeApi>("https://www.bilibili.com", false);
 
+            // 添加注入
+            services.AddBiliBiliClientApi<IArticleApi>("https://api.bilibili.com");
+
             //qinglong
             var qinglongHost = configuration["QL_URL"] ?? "http://localhost:5600";
             services

--- a/src/Ray.BiliBiliTool.Application/DailyTaskAppService.cs
+++ b/src/Ray.BiliBiliTool.Application/DailyTaskAppService.cs
@@ -79,6 +79,7 @@ namespace Ray.BiliBiliTool.Application
 
             DailyTaskInfo dailyTaskInfo = await GetDailyTaskStatus();
             await WatchAndShareVideo(dailyTaskInfo);
+            // TODO 允许切换模式至投币给专栏
             await AddCoinsForVideo(userInfo);
 
             //签到：

--- a/src/Ray.BiliBiliTool.DomainService/ArticleDomainService.cs
+++ b/src/Ray.BiliBiliTool.DomainService/ArticleDomainService.cs
@@ -1,0 +1,162 @@
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Ray.BiliBiliTool.Agent;
+using Ray.BiliBiliTool.Agent.BiliBiliAgent.Dtos;
+using Ray.BiliBiliTool.Agent.BiliBiliAgent.Dtos.Article;
+using Ray.BiliBiliTool.Agent.BiliBiliAgent.Interfaces;
+using Ray.BiliBiliTool.Config.Options;
+using Ray.BiliBiliTool.DomainService.Interfaces;
+
+namespace Ray.BiliBiliTool.DomainService;
+
+public class ArticleDomainService : IArticleDomainService
+{
+    private readonly IArticleApi _articleApi;
+    private readonly BiliCookie _biliCookie;
+    private readonly ILogger<ArticleDomainService> _logger;
+    private readonly DailyTaskOptions _dailyTaskOptions;
+    private readonly ICoinDomainService _coinDomainService;
+
+    public ArticleDomainService(IArticleApi articleApi, BiliCookie biliCookie, ILogger<ArticleDomainService> logger, IOptionsMonitor<DailyTaskOptions> dailyTaskOptions, ICoinDomainService coinDomainService)
+    {
+        _articleApi = articleApi;
+        _biliCookie = biliCookie;
+        _logger = logger;
+        _coinDomainService = coinDomainService;
+        _dailyTaskOptions = dailyTaskOptions.CurrentValue;
+    }
+
+    /// <summary>
+    /// 投币专栏任务
+    /// </summary>
+    /// <returns></returns>
+    public async Task AddCoinForArticles()
+    {
+        var donateCoinsCounts = await CalculateDonateCoinsCounts();
+
+        if (donateCoinsCounts == 0)
+        {
+            return;
+        }
+
+
+            
+    }
+
+
+
+    /// <summary>
+    /// 给某一篇专栏投币
+    /// </summary>
+    /// <param name="cvid">文章cvid</param>
+    /// <param name="mid">文章作者mid</param>
+    /// <returns>投币是否成功</returns>
+    public async Task<bool> AddCoinForArticle(long cvid, long mid)
+    {
+        BiliApiResponse result;
+        try
+        {
+            var refer = $"https://www.bilibili.com/read/cv{cvid}/?from=search&spm_id_from=333.337.0.0";
+            result = await _articleApi.AddCoinForArticle(new AddCoinForArticleRequest(cvid, mid, _biliCookie.BiliJct),
+                refer);
+        }
+        catch (Exception )
+        {
+            return false;
+        }
+        
+        if (result.Code == 0)
+        {
+            _logger.LogInformation("投币成功，经验+10 √" );
+            return true;
+        }
+        else
+        {
+            _logger.LogError("投币错误 {message}", result.Message);
+            return false;
+        }
+    }
+
+
+    /// <summary>
+    /// 计算所需要投的硬币数量
+    /// </summary>
+    /// <returns>硬币数量</returns>
+    public async Task<int> CalculateDonateCoinsCounts()
+    {
+        int needCoins = await GetNeedDonateCoinCounts();
+
+        int protectedCoins = _dailyTaskOptions.NumberOfProtectedCoins;
+        if (needCoins <= 0) return 0;
+
+        //投币前硬币余额
+        decimal coinBalance = await _coinDomainService.GetCoinBalance();
+        _logger.LogInformation("【投币前余额】 : {coinBalance}", coinBalance);
+        _ = int.TryParse(decimal.Truncate(coinBalance - protectedCoins).ToString(), out int unprotectedCoins);
+
+        if (coinBalance <= 0)
+        {
+            _logger.LogInformation("因硬币余额不足，今日暂不执行投币任务");
+            return 0;
+        }
+
+        if (coinBalance <= protectedCoins)
+        {
+            _logger.LogInformation("因硬币余额达到或低于保留值，今日暂不执行投币任务");
+            return 0;
+        }
+
+        //余额小于目标投币数，按余额投
+        if (coinBalance < needCoins)
+        {
+            _ = int.TryParse(decimal.Truncate(coinBalance).ToString(), out needCoins);
+            _logger.LogInformation("因硬币余额不足，目标投币数调整为: {needCoins}", needCoins);
+            return needCoins;
+        }
+
+        //投币后余额小于等于保护值，按保护值允许投
+        if (coinBalance - needCoins <= protectedCoins)
+        {
+            //排除需投等于保护后可投数量相等时的情况
+            if (unprotectedCoins != needCoins)
+            {
+                needCoins = unprotectedCoins;
+                _logger.LogInformation("因硬币余额投币后将达到或低于保留值，目标投币数调整为: {needCoins}", needCoins);
+                return needCoins;
+            }
+        }
+
+        return 0;
+    }
+
+    public async Task<int> GetNeedDonateCoinCounts()
+    {
+        int configCoins = _dailyTaskOptions.NumberOfCoins;
+
+        if (configCoins <= 0)
+        {
+            _logger.LogInformation("已配置为跳过投币任务");
+            return configCoins;
+        }
+
+        //已投的硬币
+        int alreadyCoins = await _coinDomainService.GetDonatedCoins();
+        
+        int targetCoins = configCoins;
+
+        _logger.LogInformation("【今日已投】{already}枚", alreadyCoins);
+        _logger.LogInformation("【目标欲投】{already}枚", targetCoins);
+
+        if (targetCoins > alreadyCoins)
+        {
+            int needCoins = targetCoins - alreadyCoins;
+            _logger.LogInformation("【还需再投】{need}枚", needCoins);
+            return needCoins;
+        }
+
+        _logger.LogInformation("已完成投币任务，不需要再投啦~");
+        return 0;
+    }
+}

--- a/src/Ray.BiliBiliTool.DomainService/Interfaces/IArticleDomainService.cs
+++ b/src/Ray.BiliBiliTool.DomainService/Interfaces/IArticleDomainService.cs
@@ -1,0 +1,9 @@
+﻿using System.Threading.Tasks;
+
+namespace Ray.BiliBiliTool.DomainService.Interfaces;
+
+public interface IArticleDomainService :IDomainService
+{
+    // Task<int> GetArticleCountByUp(long upId);
+    Task<bool> AddCoinForArticle(long cvid, long mid);
+}

--- a/src/Ray.BiliBiliTool.DomainService/LiveDomainService.cs
+++ b/src/Ray.BiliBiliTool.DomainService/LiveDomainService.cs
@@ -616,7 +616,11 @@ namespace Ray.BiliBiliTool.DomainService
 
                 // 用以排除有牌子无直播间的up主
                 if (spaceInfo.Data.Live_room is null)
+                {
+                    _logger.LogInformation("【主播】{name} 直播间id获取失败，已跳过",medal.Target_name);
                     continue;
+                }
+                    
                 
                 var roomId = spaceInfo.Data.Live_room.Roomid;
 

--- a/src/Ray.BiliBiliTool.DomainService/LiveDomainService.cs
+++ b/src/Ray.BiliBiliTool.DomainService/LiveDomainService.cs
@@ -614,6 +614,10 @@ namespace Ray.BiliBiliTool.DomainService
                     continue;
                 }
 
+                // 用以排除有牌子无直播间的up主
+                if (spaceInfo.Data.Live_room is null)
+                    continue;
+                
                 var roomId = spaceInfo.Data.Live_room.Roomid;
 
                 // 获取直播间详细信息

--- a/test/DomainServiceTest/ArticleDomainServiceTest.cs
+++ b/test/DomainServiceTest/ArticleDomainServiceTest.cs
@@ -1,0 +1,25 @@
+﻿namespace DomainServiceTest;
+
+public class ArticleDomainServiceTest
+{
+    public ArticleDomainServiceTest()
+    {
+        Program.CreateHost(new[] { "--ENVIRONMENT=Development" });
+    }
+
+
+    
+
+
+    [Fact]
+    public async Task AddCoinForArticleTest()
+    {
+        using var scope = Global.ServiceProviderRoot.CreateScope();
+        var config = Global.ConfigurationRoot;
+        var domainService = scope.ServiceProvider.GetRequiredService<IArticleDomainService>();
+
+        // 测试用的专栏：https://www.bilibili.com/read/cv5806746/?from=search&spm_id_from=333.337.0.0
+
+        await domainService.AddCoinForArticle(5806746, 486980924);
+    }
+}


### PR DESCRIPTION
<!-- 该操作会向作者源仓库发起PR，是用来向源仓库贡献自己代码的 -->
<!-- 请PR到我的develop分支上，main分支不接受直接PR -->

<!-- 如果您明白正在做什么，请将下一行中符号【】内的文字由“no”修改为“yes”（不含引号） -->
<!-- 请问您是否明白：【yes】 -->

【内容】：
解决 #608  所提出的问题。在通过粉丝牌获取主播列表时，跳过有粉丝牌但是没有直播间的主播。

问题是由于当某位主播没有开通直播间时，会导致`spaceInfo.Data.Live_room`的值为 null 进而导致在执行`var roomId = spaceInfo.Data.Live_room.Roomid;`时报错。

该pr由 @MTChaoyi 测试通过。

> 无对应情况的模拟测试可以修改两个`mid`的赋值语句指定`mid`为 1459104794

附图为排查出的问题：
![6991632908ccf2f3bc24260ec434ac9e](https://github.com/RayWangQvQ/BiliBiliToolPro/assets/63545780/841f040f-2897-4630-b1d6-72cf3f41f519)

指定`mid`的模拟测试结果（主播名称为粉丝牌信息直接获取，未被修改）：
![image](https://github.com/RayWangQvQ/BiliBiliToolPro/assets/63545780/85ea658d-c602-46ad-a8fd-cc403948c932)


