### PR TITLE
修复错误，并增加专栏投币功能

### DIFF
--- a/src/Ray.BiliBiliTool.Agent/BiliBiliAgent/Dtos/Article/AddCoinForArticleRequest.cs
+++ b/src/Ray.BiliBiliTool.Agent/BiliBiliAgent/Dtos/Article/AddCoinForArticleRequest.cs
@@ -1,0 +1,22 @@
+﻿namespace Ray.BiliBiliTool.Agent.BiliBiliAgent.Dtos.Article;
+
+public class AddCoinForArticleRequest
+{
+    public AddCoinForArticleRequest(long cvid,long mid,string csrf)
+    {
+        Aid = cvid;
+        Upid = mid;
+        Csrf = csrf;
+    }
+
+    public long Aid { get; set; }
+
+    public long Upid { get; set; }
+
+    public int Multiply { get; set; } = 1;
+
+    // 必须为2
+    public int Avtype { get; private set; } = 2;
+
+    public string Csrf { get; set; }
+}

--- a/src/Ray.BiliBiliTool.Agent/BiliBiliAgent/Dtos/Article/SearchArticleInfoResponse.cs
+++ b/src/Ray.BiliBiliTool.Agent/BiliBiliAgent/Dtos/Article/SearchArticleInfoResponse.cs
@@ -1,0 +1,10 @@
+﻿namespace Ray.BiliBiliTool.Agent.BiliBiliAgent.Dtos.Article;
+
+public class SearchArticleInfoResponse
+{
+    public int Like { get; set; }
+
+    public int Coin { get; set; }
+
+    public long Mid { get; set; }
+}

--- a/src/Ray.BiliBiliTool.Agent/BiliBiliAgent/Dtos/Article/SearchArticlesByUpIdFullFto.cs
+++ b/src/Ray.BiliBiliTool.Agent/BiliBiliAgent/Dtos/Article/SearchArticlesByUpIdFullFto.cs
@@ -1,0 +1,19 @@
+﻿namespace Ray.BiliBiliTool.Agent.BiliBiliAgent.Dtos.Article;
+
+public class SearchArticlesByUpIdDto
+{
+    public long Mid { get; set; }
+
+    public int Pn { get; set; } = 1;
+
+    public int Ps { get; set; } = 30;
+
+    public string Sort { get; set; } = "publish_time";
+}
+
+public class SearchArticlesByUpIdFullFto : SearchArticlesByUpIdDto
+{
+    public string w_rid { get; set; }
+
+    public long wts { get; set; }
+}

--- a/src/Ray.BiliBiliTool.Agent/BiliBiliAgent/Dtos/Article/SearchUpArticlesResponse.cs
+++ b/src/Ray.BiliBiliTool.Agent/BiliBiliAgent/Dtos/Article/SearchUpArticlesResponse.cs
@@ -4,7 +4,7 @@ namespace Ray.BiliBiliTool.Agent.BiliBiliAgent.Dtos.Article;
 
 public class SearchUpArticlesResponse
 {
-    public List<ArticleInfo> ArticleInfoList { get; set; }
+    public List<ArticleInfo> Articles { get; set; }
     public int Count { get; set; }
 
 }

--- a/src/Ray.BiliBiliTool.Agent/BiliBiliAgent/Dtos/Article/SearchUpArticlesResponse.cs
+++ b/src/Ray.BiliBiliTool.Agent/BiliBiliAgent/Dtos/Article/SearchUpArticlesResponse.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections.Generic;
+
+namespace Ray.BiliBiliTool.Agent.BiliBiliAgent.Dtos.Article;
+
+public class SearchUpArticlesResponse
+{
+    public List<ArticleInfo> ArticleInfoList { get; set; }
+    public int Count { get; set; }
+
+}
+
+public class ArticleInfo
+{
+    public long Id { get; set; }
+
+    public string Title { get; set; }
+
+}

--- a/src/Ray.BiliBiliTool.Agent/BiliBiliAgent/Interfaces/IArticleApi.cs
+++ b/src/Ray.BiliBiliTool.Agent/BiliBiliAgent/Interfaces/IArticleApi.cs
@@ -17,6 +17,21 @@ namespace Ray.BiliBiliTool.Agent.BiliBiliAgent.Interfaces
         [HttpPost("/x/web-interface/coin/add")]
         Task<BiliApiResponse> AddCoinForArticle([FormContent] AddCoinForArticleRequest request, [Header("referer")] string refer = "https://www.bilibili.com/read/cv5806746/?from=search&spm_id_from=333.337.0.0");
 
+
+        [Header("Referer", "https://www.bilibili.com/")]
+        [Header("Origin", "https://space.bilibili.com")]
+        [HttpGet("/x/space/wbi/article")]
+        Task<BiliApiResponse<SearchUpArticlesResponse>> SearchUpArticlesByUpId(
+            [PathQuery] SearchArticlesByUpIdFullFto request);
+
+        /// <summary>
+        /// 获取专栏详情
+        /// </summary>
+        /// <param name="cvid"></param>
+        /// <returns></returns>
+        [HttpGet("/x/article/viewinfo?id={cvid}")]
+        Task<BiliApiResponse<SearchArticleInfoResponse>> SearchArticleInfo(long cvid);
+
     }
 
     

--- a/src/Ray.BiliBiliTool.Agent/BiliBiliAgent/Interfaces/IArticleApi.cs
+++ b/src/Ray.BiliBiliTool.Agent/BiliBiliAgent/Interfaces/IArticleApi.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Ray.BiliBiliTool.Agent.BiliBiliAgent.Dtos;
+using Ray.BiliBiliTool.Agent.BiliBiliAgent.Dtos.Article;
+using Ray.BiliBiliTool.Agent.BiliBiliAgent.Dtos.Video;
+using WebApiClientCore.Attributes;
+
+namespace Ray.BiliBiliTool.Agent.BiliBiliAgent.Interfaces
+{
+    
+    [Header("Host", "api.bilibili.com")]
+    public interface IArticleApi : IBiliBiliApi
+    {
+        [Header("Content-Type", "application/x-www-form-urlencoded")]
+        [Header("Origin", "https://www.bilibili.com")]
+        [HttpPost("/x/web-interface/coin/add")]
+        Task<BiliApiResponse> AddCoinForArticle([FormContent] AddCoinForArticleRequest request, [Header("referer")] string refer = "https://www.bilibili.com/read/cv5806746/?from=search&spm_id_from=333.337.0.0");
+
+    }
+
+    
+}

--- a/src/Ray.BiliBiliTool.Agent/Extensions/ServiceCollectionExtension.cs
+++ b/src/Ray.BiliBiliTool.Agent/Extensions/ServiceCollectionExtension.cs
@@ -73,6 +73,9 @@ namespace Ray.BiliBiliTool.Agent.Extensions
             services.AddBiliBiliClientApi<ILiveTraceApi>("https://live-trace.bilibili.com");
             services.AddBiliBiliClientApi<IHomeApi>("https://www.bilibili.com", false);
 
+            // 添加注入
+            services.AddBiliBiliClientApi<IArticleApi>("https://api.bilibili.com");
+
             //qinglong
             var qinglongHost = configuration["QL_URL"] ?? "http://localhost:5600";
             services

--- a/src/Ray.BiliBiliTool.Application/DailyTaskAppService.cs
+++ b/src/Ray.BiliBiliTool.Application/DailyTaskAppService.cs
@@ -23,6 +23,7 @@ namespace Ray.BiliBiliTool.Application
         private readonly ILogger<DailyTaskAppService> _logger;
         private readonly IAccountDomainService _accountDomainService;
         private readonly IVideoDomainService _videoDomainService;
+        private readonly IArticleDomainService _articleDomainService;
         private readonly IDonateCoinDomainService _donateCoinDomainService;
         private readonly IMangaDomainService _mangaDomainService;
         private readonly ILiveDomainService _liveDomainService;
@@ -41,6 +42,7 @@ namespace Ray.BiliBiliTool.Application
             IOptionsMonitor<Dictionary<string, int>> dicOptions,
             IAccountDomainService accountDomainService,
             IVideoDomainService videoDomainService,
+            IArticleDomainService articleDomainService,
             IDonateCoinDomainService donateCoinDomainService,
             IMangaDomainService mangaDomainService,
             ILiveDomainService liveDomainService,
@@ -56,6 +58,7 @@ namespace Ray.BiliBiliTool.Application
             _expDic = dicOptions.Get(Constants.OptionsNames.ExpDictionaryName);
             _accountDomainService = accountDomainService;
             _videoDomainService = videoDomainService;
+            _articleDomainService = articleDomainService;
             _donateCoinDomainService = donateCoinDomainService;
             _mangaDomainService = mangaDomainService;
             _liveDomainService = liveDomainService;
@@ -168,7 +171,9 @@ namespace Ray.BiliBiliTool.Application
                 _logger.LogInformation("已经为LV6大佬，开始白嫖");
                 return;
             }
-            await _donateCoinDomainService.AddCoinsForVideos();
+            // await _donateCoinDomainService.AddCoinsForVideos();
+            await _articleDomainService.AddCoinForArticles();
+
         }
 
         /// <summary>

--- a/src/Ray.BiliBiliTool.Application/DailyTaskAppService.cs
+++ b/src/Ray.BiliBiliTool.Application/DailyTaskAppService.cs
@@ -79,6 +79,7 @@ namespace Ray.BiliBiliTool.Application
 
             DailyTaskInfo dailyTaskInfo = await GetDailyTaskStatus();
             await WatchAndShareVideo(dailyTaskInfo);
+            // TODO 允许切换模式至投币给专栏
             await AddCoinsForVideo(userInfo);
 
             //签到：

--- a/src/Ray.BiliBiliTool.Config/Options/DailyTaskOptions.cs
+++ b/src/Ray.BiliBiliTool.Config/Options/DailyTaskOptions.cs
@@ -19,6 +19,11 @@ namespace Ray.BiliBiliTool.Config.Options
         public bool IsShareVideo { get; set; }
 
         /// <summary>
+        /// 是否开启专栏投币模式
+        /// </summary>
+        public bool IsDonateCoinForArticle { get; set; }
+
+        /// <summary>
         /// 每日设定的投币数 [0,5]
         /// </summary>
         public int NumberOfCoins { get; set; } = 5;

--- a/src/Ray.BiliBiliTool.Console/appsettings.json
+++ b/src/Ray.BiliBiliTool.Console/appsettings.json
@@ -6,6 +6,7 @@
     "Cron": "0 15 * * *",
     "IsWatchVideo": true, //是否观看视频
     "IsShareVideo": true, //是否分享视频
+    "IsDonateCoinForArticle": false,
     "NumberOfCoins": 5, //每日设定的投币数 [0,5]
     "NumberOfProtectedCoins": 0, // 要保留的硬币数量 [0,int_max]，0 为不保留，int_max 通常取 (2^31)-1
     "SaveCoinsWhenLv6": false, //达到六级后是否开始白嫖[false,true]

--- a/src/Ray.BiliBiliTool.Console/appsettings.json
+++ b/src/Ray.BiliBiliTool.Console/appsettings.json
@@ -1,5 +1,5 @@
 {
-  "RunTasks": "", //要运行的任务名称[Daily,LiveLottery,UnfollowBatched,VipBigPoint,Test]，多个使用&分隔，如“Daily&LiveLottery”,建议使用命令行参数指定
+  "RunTasks": "Daily", //要运行的任务名称[Daily,LiveLottery,UnfollowBatched,VipBigPoint,Test]，多个使用&分隔，如“Daily&LiveLottery”,建议使用命令行参数指定
 
   //程序自定义个性化配置
   "DailyTaskConfig": {

--- a/src/Ray.BiliBiliTool.DomainService/ArticleDomainService.cs
+++ b/src/Ray.BiliBiliTool.DomainService/ArticleDomainService.cs
@@ -1,0 +1,162 @@
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Ray.BiliBiliTool.Agent;
+using Ray.BiliBiliTool.Agent.BiliBiliAgent.Dtos;
+using Ray.BiliBiliTool.Agent.BiliBiliAgent.Dtos.Article;
+using Ray.BiliBiliTool.Agent.BiliBiliAgent.Interfaces;
+using Ray.BiliBiliTool.Config.Options;
+using Ray.BiliBiliTool.DomainService.Interfaces;
+
+namespace Ray.BiliBiliTool.DomainService;
+
+public class ArticleDomainService : IArticleDomainService
+{
+    private readonly IArticleApi _articleApi;
+    private readonly BiliCookie _biliCookie;
+    private readonly ILogger<ArticleDomainService> _logger;
+    private readonly DailyTaskOptions _dailyTaskOptions;
+    private readonly ICoinDomainService _coinDomainService;
+
+    public ArticleDomainService(IArticleApi articleApi, BiliCookie biliCookie, ILogger<ArticleDomainService> logger, IOptionsMonitor<DailyTaskOptions> dailyTaskOptions, ICoinDomainService coinDomainService)
+    {
+        _articleApi = articleApi;
+        _biliCookie = biliCookie;
+        _logger = logger;
+        _coinDomainService = coinDomainService;
+        _dailyTaskOptions = dailyTaskOptions.CurrentValue;
+    }
+
+    /// <summary>
+    /// 投币专栏任务
+    /// </summary>
+    /// <returns></returns>
+    public async Task AddCoinForArticles()
+    {
+        var donateCoinsCounts = await CalculateDonateCoinsCounts();
+
+        if (donateCoinsCounts == 0)
+        {
+            return;
+        }
+
+
+            
+    }
+
+
+
+    /// <summary>
+    /// 给某一篇专栏投币
+    /// </summary>
+    /// <param name="cvid">文章cvid</param>
+    /// <param name="mid">文章作者mid</param>
+    /// <returns>投币是否成功</returns>
+    public async Task<bool> AddCoinForArticle(long cvid, long mid)
+    {
+        BiliApiResponse result;
+        try
+        {
+            var refer = $"https://www.bilibili.com/read/cv{cvid}/?from=search&spm_id_from=333.337.0.0";
+            result = await _articleApi.AddCoinForArticle(new AddCoinForArticleRequest(cvid, mid, _biliCookie.BiliJct),
+                refer);
+        }
+        catch (Exception )
+        {
+            return false;
+        }
+        
+        if (result.Code == 0)
+        {
+            _logger.LogInformation("投币成功，经验+10 √" );
+            return true;
+        }
+        else
+        {
+            _logger.LogError("投币错误 {message}", result.Message);
+            return false;
+        }
+    }
+
+
+    /// <summary>
+    /// 计算所需要投的硬币数量
+    /// </summary>
+    /// <returns>硬币数量</returns>
+    public async Task<int> CalculateDonateCoinsCounts()
+    {
+        int needCoins = await GetNeedDonateCoinCounts();
+
+        int protectedCoins = _dailyTaskOptions.NumberOfProtectedCoins;
+        if (needCoins <= 0) return 0;
+
+        //投币前硬币余额
+        decimal coinBalance = await _coinDomainService.GetCoinBalance();
+        _logger.LogInformation("【投币前余额】 : {coinBalance}", coinBalance);
+        _ = int.TryParse(decimal.Truncate(coinBalance - protectedCoins).ToString(), out int unprotectedCoins);
+
+        if (coinBalance <= 0)
+        {
+            _logger.LogInformation("因硬币余额不足，今日暂不执行投币任务");
+            return 0;
+        }
+
+        if (coinBalance <= protectedCoins)
+        {
+            _logger.LogInformation("因硬币余额达到或低于保留值，今日暂不执行投币任务");
+            return 0;
+        }
+
+        //余额小于目标投币数，按余额投
+        if (coinBalance < needCoins)
+        {
+            _ = int.TryParse(decimal.Truncate(coinBalance).ToString(), out needCoins);
+            _logger.LogInformation("因硬币余额不足，目标投币数调整为: {needCoins}", needCoins);
+            return needCoins;
+        }
+
+        //投币后余额小于等于保护值，按保护值允许投
+        if (coinBalance - needCoins <= protectedCoins)
+        {
+            //排除需投等于保护后可投数量相等时的情况
+            if (unprotectedCoins != needCoins)
+            {
+                needCoins = unprotectedCoins;
+                _logger.LogInformation("因硬币余额投币后将达到或低于保留值，目标投币数调整为: {needCoins}", needCoins);
+                return needCoins;
+            }
+        }
+
+        return 0;
+    }
+
+    public async Task<int> GetNeedDonateCoinCounts()
+    {
+        int configCoins = _dailyTaskOptions.NumberOfCoins;
+
+        if (configCoins <= 0)
+        {
+            _logger.LogInformation("已配置为跳过投币任务");
+            return configCoins;
+        }
+
+        //已投的硬币
+        int alreadyCoins = await _coinDomainService.GetDonatedCoins();
+        
+        int targetCoins = configCoins;
+
+        _logger.LogInformation("【今日已投】{already}枚", alreadyCoins);
+        _logger.LogInformation("【目标欲投】{already}枚", targetCoins);
+
+        if (targetCoins > alreadyCoins)
+        {
+            int needCoins = targetCoins - alreadyCoins;
+            _logger.LogInformation("【还需再投】{need}枚", needCoins);
+            return needCoins;
+        }
+
+        _logger.LogInformation("已完成投币任务，不需要再投啦~");
+        return 0;
+    }
+}

--- a/src/Ray.BiliBiliTool.DomainService/DonateCoinDomainService.cs
+++ b/src/Ray.BiliBiliTool.DomainService/DonateCoinDomainService.cs
@@ -124,7 +124,7 @@ namespace Ray.BiliBiliTool.DomainService
             }
 
             if (success == needCoins)
-                _logger.LogInformation("投币任务完成");
+                _logger.LogInformation("视频投币任务完成");
             else
                 _logger.LogInformation("投币尝试超过10次，已终止");
 

--- a/src/Ray.BiliBiliTool.DomainService/Interfaces/IArticleDomainService.cs
+++ b/src/Ray.BiliBiliTool.DomainService/Interfaces/IArticleDomainService.cs
@@ -4,9 +4,7 @@ namespace Ray.BiliBiliTool.DomainService.Interfaces;
 
 public interface IArticleDomainService : IDomainService
 {
-    // Task<int> GetArticleCountByUp(long upId);
     Task<bool> AddCoinForArticle(long cvid, long mid);
 
-    Task<int> CalculateDonateCoinsCounts();
-    Task AddCoinForArticles();
+    Task<bool> AddCoinForArticles();
 }

--- a/src/Ray.BiliBiliTool.DomainService/Interfaces/IArticleDomainService.cs
+++ b/src/Ray.BiliBiliTool.DomainService/Interfaces/IArticleDomainService.cs
@@ -2,8 +2,11 @@
 
 namespace Ray.BiliBiliTool.DomainService.Interfaces;
 
-public interface IArticleDomainService :IDomainService
+public interface IArticleDomainService : IDomainService
 {
     // Task<int> GetArticleCountByUp(long upId);
     Task<bool> AddCoinForArticle(long cvid, long mid);
+
+    Task<int> CalculateDonateCoinsCounts();
+    Task AddCoinForArticles();
 }

--- a/src/Ray.BiliBiliTool.DomainService/Interfaces/IArticleDomainService.cs
+++ b/src/Ray.BiliBiliTool.DomainService/Interfaces/IArticleDomainService.cs
@@ -1,0 +1,9 @@
+﻿using System.Threading.Tasks;
+
+namespace Ray.BiliBiliTool.DomainService.Interfaces;
+
+public interface IArticleDomainService :IDomainService
+{
+    // Task<int> GetArticleCountByUp(long upId);
+    Task<bool> AddCoinForArticle(long cvid, long mid);
+}

--- a/src/Ray.BiliBiliTool.DomainService/LiveDomainService.cs
+++ b/src/Ray.BiliBiliTool.DomainService/LiveDomainService.cs
@@ -616,7 +616,11 @@ namespace Ray.BiliBiliTool.DomainService
 
                 // 用以排除有牌子无直播间的up主
                 if (spaceInfo.Data.Live_room is null)
+                {
+                    _logger.LogInformation("【主播】{name} 直播间id获取失败，已跳过",medal.Target_name);
                     continue;
+                }
+                    
                 
                 var roomId = spaceInfo.Data.Live_room.Roomid;
 

--- a/src/Ray.BiliBiliTool.DomainService/LiveDomainService.cs
+++ b/src/Ray.BiliBiliTool.DomainService/LiveDomainService.cs
@@ -614,6 +614,10 @@ namespace Ray.BiliBiliTool.DomainService
                     continue;
                 }
 
+                // 用以排除有牌子无直播间的up主
+                if (spaceInfo.Data.Live_room is null)
+                    continue;
+                
                 var roomId = spaceInfo.Data.Live_room.Roomid;
 
                 // 获取直播间详细信息

--- a/test/DomainServiceTest/ArticleDomainServiceTest.cs
+++ b/test/DomainServiceTest/ArticleDomainServiceTest.cs
@@ -12,19 +12,6 @@ public class ArticleDomainServiceTest
     }
 
     [Fact]
-    public async Task CalculateDonateCoinsCountsTest()
-    {
-        using var scope = Global.ServiceProviderRoot.CreateScope();
-        var config = Global.ConfigurationRoot;
-        var domainService = scope.ServiceProvider.GetRequiredService<IArticleDomainService>();
-
-        int coins = await domainService.CalculateDonateCoinsCounts();
-        _output.WriteLine($"当前测试账户应当投币{coins}枚，请根据账户硬币余额自行计算结果是否正确");
-    }
-
-
-
-    [Fact]
     public async Task AddCoinForArticleTest()
     {
         using var scope = Global.ServiceProviderRoot.CreateScope();

--- a/test/DomainServiceTest/ArticleDomainServiceTest.cs
+++ b/test/DomainServiceTest/ArticleDomainServiceTest.cs
@@ -1,0 +1,25 @@
+﻿namespace DomainServiceTest;
+
+public class ArticleDomainServiceTest
+{
+    public ArticleDomainServiceTest()
+    {
+        Program.CreateHost(new[] { "--ENVIRONMENT=Development" });
+    }
+
+
+    
+
+
+    [Fact]
+    public async Task AddCoinForArticleTest()
+    {
+        using var scope = Global.ServiceProviderRoot.CreateScope();
+        var config = Global.ConfigurationRoot;
+        var domainService = scope.ServiceProvider.GetRequiredService<IArticleDomainService>();
+
+        // 测试用的专栏：https://www.bilibili.com/read/cv5806746/?from=search&spm_id_from=333.337.0.0
+
+        await domainService.AddCoinForArticle(5806746, 486980924);
+    }
+}

--- a/test/DomainServiceTest/ArticleDomainServiceTest.cs
+++ b/test/DomainServiceTest/ArticleDomainServiceTest.cs
@@ -1,14 +1,27 @@
-﻿namespace DomainServiceTest;
+﻿using Xunit.Abstractions;
+
+namespace DomainServiceTest;
 
 public class ArticleDomainServiceTest
 {
-    public ArticleDomainServiceTest()
+    private readonly ITestOutputHelper _output;
+    public ArticleDomainServiceTest(ITestOutputHelper output)
     {
+        _output = output;
         Program.CreateHost(new[] { "--ENVIRONMENT=Development" });
     }
 
+    [Fact]
+    public async Task CalculateDonateCoinsCountsTest()
+    {
+        using var scope = Global.ServiceProviderRoot.CreateScope();
+        var config = Global.ConfigurationRoot;
+        var domainService = scope.ServiceProvider.GetRequiredService<IArticleDomainService>();
 
-    
+        int coins = await domainService.CalculateDonateCoinsCounts();
+        _output.WriteLine($"当前测试账户应当投币{coins}枚，请根据账户硬币余额自行计算结果是否正确");
+    }
+
 
 
     [Fact]
@@ -21,5 +34,15 @@ public class ArticleDomainServiceTest
         // 测试用的专栏：https://www.bilibili.com/read/cv5806746/?from=search&spm_id_from=333.337.0.0
 
         await domainService.AddCoinForArticle(5806746, 486980924);
+    }
+
+
+    [Fact]
+    public async Task AddCoinForArticlesTest()
+    {
+        using var scope = Global.ServiceProviderRoot.CreateScope();
+        var config = Global.ConfigurationRoot;
+        var domainService = scope.ServiceProvider.GetRequiredService<IArticleDomainService>();
+        await domainService.AddCoinForArticles();
     }
 }


### PR DESCRIPTION
<!-- 该操作会向作者源仓库发起PR，是用来向源仓库贡献自己代码的 -->
<!-- 请PR到我的develop分支上，main分支不接受直接PR -->

<!-- 如果您明白正在做什么，请将下一行中符号【】内的文字由“no”修改为“yes”（不含引号） -->
<!-- 请问您是否明白：【yes】 -->

## 1.修复Bug：

- 修复了在 #613 中提到的遇到没有直播间但是有粉丝牌的Up主时程序出错的问题。

 注：图为错误产生的原因

![6991632908ccf2f3bc24260ec434ac9e](https://github.com/RayWangQvQ/BiliBiliToolPro/assets/63545780/31f683a6-03a8-439c-b25e-68cee7916f10)

该功能的测试由 @MTChaoyi 进行了测试。


## 2.添加专栏投币功能：

- 添加了在 #611 中提到的专栏投币功能。

注意⚠：
1. 在`DailyTaskConfig`中添加了`IsDonateCoinForArticle`配置用以控制是否开启专栏投币功能（默认关闭）。
2. ⚠ 该功能目前只在我本人的小号上经过测试，需要更多不同的账号进行功能测试⚠。
3. 当前专栏投币功能不支持`SelectLike`参数来控制是否在投币的同时点赞。
4. 专栏投币必须填写`SupportUpIds`参数，用以抽选专栏。若无该参数，将跳过专栏投币。（future）
5. 为保证每日经验的最大获取，当专栏投币因某些问题未能完全进行（没有投出全部应投的币等情形），会进入视频投币功能，并不是完全的将硬币投给专栏。

图为专栏投币的早期版本，目前提示词已改：
![Pasted image 20231022234947](https://github.com/RayWangQvQ/BiliBiliToolPro/assets/63545780/8aebd88c-b4c9-4a68-8146-22dfb0556b5f)


## 3.添加了几个单元测试
本来是希望跳过通过单元测试来调用功能来进行测试的，但是我目前还没能找到在单元测试中阻隔api调用的方法，目前这两个单元测试只能用来部分验证运行情况。
