### PR TITLE
实现浏览会员购页面与观看正片内容功能

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -31,6 +31,7 @@
         - [3.3.8. 每月几号自动领取会员权益](#338-每月几号自动领取会员权益)
         - [3.3.9. 每月几号进行直播中心银瓜子兑换硬币](#339-每月几号进行直播中心银瓜子兑换硬币)
         - [3.3.10. Lv6后开启硬币白嫖模式](#3310-lv6后开启硬币白嫖模式)
+        - [3.3.11. 是否开启专栏投币](#3311-是否开启专栏投币)
     - [3.4. 天选时刻抽奖相关](#34-天选时刻抽奖相关)
         - [3.4.1. 根据关键字排除奖品](#341-根据关键字排除奖品)
         - [3.4.2. 根据关键字指定奖品](#342-根据关键字指定奖品)
@@ -75,6 +76,8 @@
         - [3.7.3. 定时任务相关](#373-定时任务相关)
         - [3.7.4. 定时任务](#374-定时任务)
         - [3.7.5. Crontab](#375-crontab)
+    - [3.8. 大积分相关](#38-大积分相关)
+        - [3.8.1. 自定义观看番剧](#381-自定义观看番剧)
 
 <!-- /TOC -->
 
@@ -314,6 +317,8 @@ export Ray_Serilog__WriteTo__9__Args__token="abcde"
 <a id="markdown-331-是否开启观看视频任务" name="331-是否开启观看视频任务"></a>
 #### 3.3.1. 是否开启观看视频任务
 
+当该配置被设置为`false`时会导致大积分任务中的签到领额外10点经验的任务不能自动完成。
+
 |   TITLE   | CONTENT   |
 | ---------- | -------------- |
 | 配置Key | `DailyTaskConfig:IsWatchVideo` |
@@ -436,6 +441,18 @@ export Ray_Serilog__WriteTo__9__Args__token="abcde"
 | 默认值   | false |
 | 环境变量   | `Ray_DailyTaskConfig__SaveCoinsWhenLv6` |
 | GitHub Secrets  |  |
+
+<a id="markdown-3311-是否开启专栏投币" name="3311-是否开启专栏投币"></a>
+#### 3.3.11. 是否开启专栏投币
+
+|   TITLE   | CONTENT   |
+| ---------- | -------------- |
+| 配置Key | `DailyTaskConfig:IsDonateCoinForArticle` |
+| 值域   | [true,false]|
+| 默认值   | false |
+| 环境变量   | `Ray_DailyTaskConfig__IsDonateCoinForArticle` |
+| GitHub Secrets  |  |
+
 
 <a id="markdown-34-天选时刻抽奖相关" name="34-天选时刻抽奖相关"></a>
 ### 3.4. 天选时刻抽奖相关
@@ -896,3 +913,17 @@ environment:
     0 15 * * * dotnet /app/Ray.BiliBiliTool.Console.dll --runTasks=Daily >> /var/log/cron.log
     0 22 * * * dotnet /app/Ray.BiliBiliTool.Console.dll --runTasks=LiveLottery >> /var/log/cron.log
 ```
+
+<a id="markdown-38-大积分相关" name="38-大积分相关"></a>
+### 3.8. 大积分相关
+
+<a id="markdown-381-自定义观看番剧" name="381-自定义观看番剧"></a>
+#### 3.8.1. 自定义观看番剧
+
+|   TITLE   | CONTENT   |
+| ---------- | -------------- |
+| 配置Key | `VipBigPointConfig:ViewBangumis` |
+| 值域   | 番剧的ssid（season_id） |
+| 默认值   | `33378`（名侦探柯南） |
+| 环境变量   | `Ray_VipBigPointConfig__ViewBangumis` |
+| GitHub Secrets  | |

--- a/src/Ray.BiliBiliTool.Agent/BiliBiliAgent/Dtos/Article/SearchArticlesByUpIdFullFto.cs
+++ b/src/Ray.BiliBiliTool.Agent/BiliBiliAgent/Dtos/Article/SearchArticlesByUpIdFullFto.cs
@@ -2,13 +2,17 @@
 
 public class SearchArticlesByUpIdDto
 {
-    public long Mid { get; set; }
+    public long mid { get; set; }
 
-    public int Pn { get; set; } = 1;
+    public int pn { get; set; } = 1;
 
-    public int Ps { get; set; } = 30;
+    public int ps { get; set; } = 12;
 
-    public string Sort { get; set; } = "publish_time";
+    public string sort { get; set; } = "publish_time";
+    
+    public long web_location { get; set; } = 1550101;
+    
+    public string platform { get; set; } = "web";
 }
 
 public class SearchArticlesByUpIdFullDto : SearchArticlesByUpIdDto

--- a/src/Ray.BiliBiliTool.Agent/BiliBiliAgent/Dtos/UploadVideoHeartbeatRequest.cs
+++ b/src/Ray.BiliBiliTool.Agent/BiliBiliAgent/Dtos/UploadVideoHeartbeatRequest.cs
@@ -17,6 +17,10 @@ namespace Ray.BiliBiliTool.Agent.BiliBiliAgent.Dtos
 
         public string Bvid { get; set; }
 
+        public long? Epid { get; set; }
+
+        public long? Sid { get; set; }
+
         /// <summary>
         /// 当前用户UID
         /// </summary>
@@ -48,6 +52,11 @@ namespace Ray.BiliBiliTool.Agent.BiliBiliAgent.Dtos
         /// <sample>10：课程</sample>
         /// </summary>
         public int Type { get; set; } = 3;
+
+        /// <summary>
+        /// 剧集副类型
+        /// </summary>
+        public int? Sub_type { get; set; }
 
         /// <summary>
         /// 2

--- a/src/Ray.BiliBiliTool.Agent/BiliBiliAgent/Dtos/Video/GetBangumiBySsidResponse.cs
+++ b/src/Ray.BiliBiliTool.Agent/BiliBiliAgent/Dtos/Video/GetBangumiBySsidResponse.cs
@@ -1,0 +1,45 @@
+﻿using static System.Collections.Specialized.BitVector32;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Xml.Linq;
+
+namespace Ray.BiliBiliTool.Agent.BiliBiliAgent.Dtos.Video;
+
+public class GetBangumiBySsidResponse
+{
+    public int Code { get; set; } = int.MinValue;
+
+    public string Message { get; set; }
+
+    public Result Result { get; set; }
+}
+
+public class Result
+{
+    public List<Episode> episodes { get; set; }
+}
+
+
+public class Episode
+{
+    public int aid { get; set; }
+
+    public string bvid { get; set; }
+
+    public int cid { get; set; }
+
+    public int duration { get; set; }
+
+    public int ep_id { get; set; }
+
+    public int id { get; set; }
+
+    public string long_title { get; set; }
+
+    public string share_copy { get; set; }
+
+    public int status { get; set; }
+
+
+
+}

--- a/src/Ray.BiliBiliTool.Agent/BiliBiliAgent/Dtos/ViewMall/ViewvipMallRequest.cs
+++ b/src/Ray.BiliBiliTool.Agent/BiliBiliAgent/Dtos/ViewMall/ViewvipMallRequest.cs
@@ -1,0 +1,7 @@
+﻿namespace Ray.BiliBiliTool.Agent.BiliBiliAgent.Dtos.ViewMall;
+
+public class ViewVipMallRequest
+{
+    public string Csrf { get; set; }
+    public string EventId { get; set; } = "hevent_oy4b7h3epeb";
+}

--- a/src/Ray.BiliBiliTool.Agent/BiliBiliAgent/Interfaces/IVideoApi.cs
+++ b/src/Ray.BiliBiliTool.Agent/BiliBiliAgent/Interfaces/IVideoApi.cs
@@ -73,7 +73,16 @@ namespace Ray.BiliBiliTool.Agent.BiliBiliAgent.Interfaces
         //[HttpGet("/x/space/wbi/arc/search?mid={upId}&ps={pageSize}&tid=0&pn={pageNumber}&keyword={keyword}&order=pubdate&platform=web&web_location=1550101&order_avoided=true&w_rid=5df06b1c48e2be86a96e9d0f99bf06f4&wts=1684854929")]
         [HttpGet("/x/space/wbi/arc/search")]
         Task<BiliApiResponse<SearchUpVideosResponse>> SearchVideosByUpId([PathQuery] SearchVideosByUpIdFullDto request);
-        
+
+        /// <summary>
+        /// 通过ssid获取番剧的具体信息
+        /// </summary>
+        /// <param name="Ssid"></param>
+        /// <returns></returns>
+        [HttpGet("/pgc/view/web/season?season_id={ssid}")]
+        Task<GetBangumiBySsidResponse> GetBangumiBySsid(long ssid);
+
+
     }
 
     /// <summary>

--- a/src/Ray.BiliBiliTool.Agent/BiliBiliAgent/Interfaces/IVipBigPointApi.cs
+++ b/src/Ray.BiliBiliTool.Agent/BiliBiliAgent/Interfaces/IVipBigPointApi.cs
@@ -12,31 +12,45 @@ namespace Ray.BiliBiliTool.Agent.BiliBiliAgent.Interfaces
     /// 大会员大积分
     /// </summary>
     [Header("Host", "api.bilibili.com")]
-    [Header("Referer", "https://big.bilibili.com/mobile/bigPoint/task")]
-    [Header("User-Agent", "Mozilla/5.0 (Linux; Android 6.0.1; MuMu Build/V417IR; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/66.0.3359.158 Mobile Safari/537.36 os/android model/MuMu build/6720300 osVer/6.0.1 sdkInt/23 network/2 BiliApp/6720300 mobi_app/android channel/html5_search_baidu Buvid/XZFC135F5263B6897C8A4BE7AEB125BBF10F8 sessionID/72d3f4c9 innerVer/6720310 c_locale/zh_CN s_locale/zh_CN disable_rcmd/0 6.72.0 os/android model/MuMu mobi_app/android build/6720300 channel/html5_search_baidu innerVer/6720310 osVer/6.0.1 network/2")]
     [LogFilter]
     public interface IVipBigPointApi
     {
+        [Header("Referer", "https://big.bilibili.com/mobile/bigPoint/task")]
+        [Header("User-Agent", "Mozilla/5.0 (Linux; Android 6.0.1; MuMu Build/V417IR; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/66.0.3359.158 Mobile Safari/537.36 os/android model/MuMu build/6720300 osVer/6.0.1 sdkInt/23 network/2 BiliApp/6720300 mobi_app/android channel/html5_search_baidu Buvid/XZFC135F5263B6897C8A4BE7AEB125BBF10F8 sessionID/72d3f4c9 innerVer/6720310 c_locale/zh_CN s_locale/zh_CN disable_rcmd/0 6.72.0 os/android model/MuMu mobi_app/android build/6720300 channel/html5_search_baidu innerVer/6720310 osVer/6.0.1 network/2")]
         [HttpGet("/x/vip_point/task/combine")]
         Task<BiliApiResponse<VipTaskInfo>> GetTaskList();
 
+        
+        [Header("Referer", "https://www.bilibili.com")]
         [HttpPost("/pgc/activity/score/task/sign")]
         Task<BiliApiResponse> Sign([FormContent] SignRequest request);
 
+        [Header("Referer", "https://big.bilibili.com/mobile/bigPoint/task")]
+        [Header("User-Agent", "Mozilla/5.0 (Linux; Android 6.0.1; MuMu Build/V417IR; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/66.0.3359.158 Mobile Safari/537.36 os/android model/MuMu build/6720300 osVer/6.0.1 sdkInt/23 network/2 BiliApp/6720300 mobi_app/android channel/html5_search_baidu Buvid/XZFC135F5263B6897C8A4BE7AEB125BBF10F8 sessionID/72d3f4c9 innerVer/6720310 c_locale/zh_CN s_locale/zh_CN disable_rcmd/0 6.72.0 os/android model/MuMu mobi_app/android build/6720300 channel/html5_search_baidu innerVer/6720310 osVer/6.0.1 network/2")]
         [HttpPost("/pgc/activity/score/task/receive")]
         Task<BiliApiResponse> Receive([JsonContent] ReceiveOrCompleteTaskRequest request);
 
+        [Header("Referer", "https://big.bilibili.com/mobile/bigPoint/task")]
+        [Header("User-Agent", "Mozilla/5.0 (Linux; Android 6.0.1; MuMu Build/V417IR; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/66.0.3359.158 Mobile Safari/537.36 os/android model/MuMu build/6720300 osVer/6.0.1 sdkInt/23 network/2 BiliApp/6720300 mobi_app/android channel/html5_search_baidu Buvid/XZFC135F5263B6897C8A4BE7AEB125BBF10F8 sessionID/72d3f4c9 innerVer/6720310 c_locale/zh_CN s_locale/zh_CN disable_rcmd/0 6.72.0 os/android model/MuMu mobi_app/android build/6720300 channel/html5_search_baidu innerVer/6720310 osVer/6.0.1 network/2")]
         [HttpPost("/pgc/activity/score/task/complete")]
         Task<BiliApiResponse> Complete([JsonContent] ReceiveOrCompleteTaskRequest request);
 
+        [Header("Referer", "https://big.bilibili.com/mobile/bigPoint/task")]
+        [Header("User-Agent", "Mozilla/5.0 (Linux; Android 6.0.1; MuMu Build/V417IR; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/66.0.3359.158 Mobile Safari/537.36 os/android model/MuMu build/6720300 osVer/6.0.1 sdkInt/23 network/2 BiliApp/6720300 mobi_app/android channel/html5_search_baidu Buvid/XZFC135F5263B6897C8A4BE7AEB125BBF10F8 sessionID/72d3f4c9 innerVer/6720310 c_locale/zh_CN s_locale/zh_CN disable_rcmd/0 6.72.0 os/android model/MuMu mobi_app/android build/6720300 channel/html5_search_baidu innerVer/6720310 osVer/6.0.1 network/2")]
         [HttpPost("/pgc/activity/deliver/task/complete")]
         Task<BiliApiResponse> ViewComplete([FormContent] ViewRequest request);
 
+        [Header("Referer", "https://big.bilibili.com/mobile/bigPoint/task")]
+        [Header("User-Agent", "Mozilla/5.0 (Linux; Android 6.0.1; MuMu Build/V417IR; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/66.0.3359.158 Mobile Safari/537.36 os/android model/MuMu build/6720300 osVer/6.0.1 sdkInt/23 network/2 BiliApp/6720300 mobi_app/android channel/html5_search_baidu Buvid/XZFC135F5263B6897C8A4BE7AEB125BBF10F8 sessionID/72d3f4c9 innerVer/6720310 c_locale/zh_CN s_locale/zh_CN disable_rcmd/0 6.72.0 os/android model/MuMu mobi_app/android build/6720300 channel/html5_search_baidu innerVer/6720310 osVer/6.0.1 network/2")]
         [HttpGet("/x/vip/privilege/my")]
         Task<BiliApiResponse<VouchersInfoResponse>> GetVouchersInfo();
 
+        [Header("Referer", "https://big.bilibili.com/mobile/bigPoint/task")]
+        [Header("User-Agent", "Mozilla/5.0 (Linux; Android 6.0.1; MuMu Build/V417IR; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/66.0.3359.158 Mobile Safari/537.36 os/android model/MuMu build/6720300 osVer/6.0.1 sdkInt/23 network/2 BiliApp/6720300 mobi_app/android channel/html5_search_baidu Buvid/XZFC135F5263B6897C8A4BE7AEB125BBF10F8 sessionID/72d3f4c9 innerVer/6720310 c_locale/zh_CN s_locale/zh_CN disable_rcmd/0 6.72.0 os/android model/MuMu mobi_app/android build/6720300 channel/html5_search_baidu innerVer/6720310 osVer/6.0.1 network/2")]
         [Header("Content-Type", "application/x-www-form-urlencoded; charset=UTF-8")]
         [HttpPost("/x/vip/experience/add")]
         Task<BiliApiResponse> GetVipExperience([FormContent] VipExperienceRequest request);
+
+        
     }
 }

--- a/src/Ray.BiliBiliTool.Agent/BiliBiliAgent/Interfaces/IVipMallApi.cs
+++ b/src/Ray.BiliBiliTool.Agent/BiliBiliAgent/Interfaces/IVipMallApi.cs
@@ -1,0 +1,13 @@
+﻿using Ray.BiliBiliTool.Agent.BiliBiliAgent.Dtos;
+using System.Threading.Tasks;
+using WebApiClientCore.Attributes;
+using Ray.BiliBiliTool.Agent.BiliBiliAgent.Dtos.ViewMall;
+
+namespace Ray.BiliBiliTool.Agent.BiliBiliAgent.Interfaces;
+
+[Header("Host", "show.bilibili.com")]
+public interface IVipMallApi
+{
+    [HttpPost("/api/activity/fire/common/event/dispatch")]
+    Task<BiliApiResponse> ViewVipMall([JsonContent] ViewVipMallRequest request);
+}

--- a/src/Ray.BiliBiliTool.Agent/Extensions/ServiceCollectionExtension.cs
+++ b/src/Ray.BiliBiliTool.Agent/Extensions/ServiceCollectionExtension.cs
@@ -75,6 +75,7 @@ namespace Ray.BiliBiliTool.Agent.Extensions
 
             // 添加注入
             services.AddBiliBiliClientApi<IArticleApi>("https://api.bilibili.com");
+            services.AddBiliBiliClientApi<IVipMallApi>("https://show.bilibili.com");
 
             //qinglong
             var qinglongHost = configuration["QL_URL"] ?? "http://localhost:5600";

--- a/src/Ray.BiliBiliTool.Application.Contracts/IVipBigPointAppService.cs
+++ b/src/Ray.BiliBiliTool.Application.Contracts/IVipBigPointAppService.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Text;
 using System.Threading.Tasks;
+using Ray.BiliBiliTool.DomainService.Dtos;
 
 namespace Ray.BiliBiliTool.Application.Contracts
 {
@@ -14,5 +15,8 @@ namespace Ray.BiliBiliTool.Application.Contracts
     public interface IVipBigPointAppService : IAppService
     {
         Task VipExpress();
+        Task<bool> WatchBangumi();
     }
+
+
 }

--- a/src/Ray.BiliBiliTool.Application.Contracts/Ray.BiliBiliTool.Application.Contracts.csproj
+++ b/src/Ray.BiliBiliTool.Application.Contracts/Ray.BiliBiliTool.Application.Contracts.csproj
@@ -8,4 +8,8 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\Ray.BiliBiliTool.DomainService\Ray.BiliBiliTool.DomainService.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/src/Ray.BiliBiliTool.Application/DailyTaskAppService.cs
+++ b/src/Ray.BiliBiliTool.Application/DailyTaskAppService.cs
@@ -95,9 +95,6 @@ namespace Ray.BiliBiliTool.Application
             await ReceiveVipPrivilege(userInfo);
             await ReceiveMangaVipReward(userInfo);
 
-            //TODO 大会员领经验
-
-
             await Charge(userInfo);
         }
 

--- a/src/Ray.BiliBiliTool.Application/VipBigPointAppService.cs
+++ b/src/Ray.BiliBiliTool.Application/VipBigPointAppService.cs
@@ -4,13 +4,17 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Ray.BiliBiliTool.Agent;
 using Ray.BiliBiliTool.Agent.BiliBiliAgent.Dtos;
+using Ray.BiliBiliTool.Agent.BiliBiliAgent.Dtos.Video;
 using Ray.BiliBiliTool.Agent.BiliBiliAgent.Dtos.ViewMall;
 using Ray.BiliBiliTool.Agent.BiliBiliAgent.Dtos.VipTask;
 using Ray.BiliBiliTool.Agent.BiliBiliAgent.Interfaces;
 using Ray.BiliBiliTool.Application.Attributes;
 using Ray.BiliBiliTool.Application.Contracts;
+using Ray.BiliBiliTool.Config.Options;
+using Ray.BiliBiliTool.DomainService.Dtos;
 using Ray.BiliBiliTool.DomainService.Interfaces;
 
 namespace Ray.BiliBiliTool.Application
@@ -25,6 +29,8 @@ namespace Ray.BiliBiliTool.Application
         private readonly IAccountDomainService _accountDomainService;
         private readonly BiliCookie _biliCookie;
         private readonly IVipMallApi _vipMallApi;
+        private readonly IVideoApi _videoApi;
+        private readonly VipBigPointOptions _vipBigPointOptions;
 
         public VipBigPointAppService(
             IConfiguration configuration,
@@ -32,8 +38,11 @@ namespace Ray.BiliBiliTool.Application
             IVipBigPointApi vipApi,
             IAccountDomainService loginDomainService,
             IVideoDomainService videoDomainService,
-            BiliCookie biliCookie, IAccountDomainService accountDomainService,
-            IVipMallApi vipMallApi)
+            BiliCookie biliCookie,
+            IAccountDomainService accountDomainService,
+            IVipMallApi vipMallApi,
+            IVideoApi videoApi,
+            IOptionsMonitor<VipBigPointOptions> vipBigPointOptions)
         {
             _configuration = configuration;
             _logger = logger;
@@ -43,6 +52,8 @@ namespace Ray.BiliBiliTool.Application
             _biliCookie = biliCookie;
             _accountDomainService = accountDomainService;
             _vipMallApi = vipMallApi;
+            _videoApi = videoApi;
+            _vipBigPointOptions = vipBigPointOptions.CurrentValue;
         }
 
         public async Task VipExpress()
@@ -114,7 +125,6 @@ namespace Ray.BiliBiliTool.Application
 
             await VipExpress();
 
-            // TODO 浏览装扮商城主页
             //签到
             taskInfo = await Sign(taskInfo);
 
@@ -134,6 +144,9 @@ namespace Ray.BiliBiliTool.Application
 
             //浏览会员购页面10秒
             taskInfo = await ViewVipMall(taskInfo);
+
+            //浏览装扮商城
+            taskInfo = await ViewDressMall(taskInfo);
 
             //观看任意正片内容
             taskInfo = await ViewVideo(taskInfo);
@@ -272,7 +285,7 @@ namespace Ray.BiliBiliTool.Application
         [TaskInterceptor("浏览追番频道页10秒", TaskLevel.Two, false)]
         private async Task<VipTaskInfo> ViewAnimate(VipTaskInfo info)
         {
-            var code = "jp_channel";
+            var code = "dress-view";
 
             CommonTaskItem targetTask = GetTarget(info);
 
@@ -308,52 +321,7 @@ namespace Ray.BiliBiliTool.Application
             {
                 return info.Task_info.Modules.First(x => x.module_title == "日常任务")
                     .common_task_item
-                    .First(x => x.task_code == "animatetab");
-            }
-
-            return info;
-        }
-
-        [TaskInterceptor("浏览影视频道页10秒", TaskLevel.Two, false)]
-        private async Task<VipTaskInfo> ViewFilmChannel(VipTaskInfo info)
-        {
-            var code = "tv_channel";
-
-            CommonTaskItem targetTask = GetTarget(info);
-
-            //如果状态不等于3，则做
-            if (targetTask.state == 3)
-            {
-                _logger.LogInformation("已完成，跳过");
-                return info;
-            }
-
-            //0需要领取
-            if (targetTask.state == 0)
-            {
-                _logger.LogInformation("开始领取任务");
-                await TryReceive(targetTask.task_code);
-            }
-
-            _logger.LogInformation("开始完成任务");
-            var re = await CompleteView(code);
-
-            //确认
-            if (re)
-            {
-                var infoResult = await _vipApi.GetTaskList();
-                if (infoResult.Code != 0) throw new Exception(infoResult.ToJsonStr());
-                info = infoResult.Data;
-                targetTask = GetTarget(info);
-
-                _logger.LogInformation("确认：{re}", targetTask.state == 3 && targetTask.complete_times >= 1);
-            }
-
-            CommonTaskItem GetTarget(VipTaskInfo info)
-            {
-                return info.Task_info.Modules.First(x => x.module_title == "日常任务")
-                    .common_task_item
-                    .First(x => x.task_code == "filmtab");
+                    .First(x => x.task_code == "dress-view");
             }
 
             return info;
@@ -410,12 +378,12 @@ namespace Ray.BiliBiliTool.Application
         {
             CommonTaskItem targetTask = GetTarget(info);
 
-            //如果状态不等于3，则做
-            if (targetTask.state == 3)
-            {
-                _logger.LogInformation("已完成，跳过");
-                return info;
-            }
+            // 如果状态不等于3，则做
+             if (targetTask.state == 3)
+             {
+                 _logger.LogInformation("已完成，跳过");
+                 return info;
+             }
 
             //0需要领取
             if (targetTask.state == 0)
@@ -425,7 +393,8 @@ namespace Ray.BiliBiliTool.Application
             }
 
             _logger.LogInformation("开始完成任务");
-            _logger.LogInformation("待开发...");//todo
+
+            await WatchBangumi();
 
             CommonTaskItem GetTarget(VipTaskInfo info)
             {
@@ -438,7 +407,7 @@ namespace Ray.BiliBiliTool.Application
         }
 
         [TaskInterceptor("购买单点付费影片（仅领取）", TaskLevel.Two, false)]
-            private async Task<VipTaskInfo> BuyVipVideo(VipTaskInfo info)
+        private async Task<VipTaskInfo> BuyVipVideo(VipTaskInfo info)
         {
             CommonTaskItem targetTask = GetTarget(info);
 
@@ -463,35 +432,6 @@ namespace Ray.BiliBiliTool.Application
                 return info.Task_info.Modules.First(x => x.module_title == "日常任务")
                     .common_task_item
                     .First(x => x.task_code == "tvodbuy");
-            }
-        }
-
-        [TaskInterceptor("购买指定大会员产品（仅领取）", TaskLevel.Two, false)]
-        private async Task<VipTaskInfo> BuyVipProduct(VipTaskInfo info)
-        {
-            CommonTaskItem targetTask = GetTarget(info);
-
-            if (targetTask.state is 3 or 1)
-            {
-                var re = targetTask.state == 1 ? "已领取" : "已完成";
-                _logger.LogInformation("{re}，跳过", re);
-                return info;
-            }
-
-            //0需要领取
-            if (targetTask.state == 0)
-            {
-                _logger.LogInformation("开始领取任务");
-                await TryReceive(targetTask.task_code);
-            }
-
-            return info;
-
-            CommonTaskItem GetTarget(VipTaskInfo info)
-            {
-                return info.Task_info.Modules.First(x => x.module_title == "日常任务")
-                    .common_task_item
-                    .First(x => x.task_code == "subscribe");
             }
         }
 
@@ -523,6 +463,52 @@ namespace Ray.BiliBiliTool.Application
                     .First(x => x.task_code == "vipmallbuy");
             }
         }
+
+        [TaskInterceptor("浏览装扮商城主页", TaskLevel.Two, false)]
+        private async Task<VipTaskInfo> ViewDressMall(VipTaskInfo info)
+        {
+            var code = "dress-view";
+
+            CommonTaskItem targetTask = GetTarget(info);
+
+            //如果状态不等于3，则做
+            if (targetTask.state == 3)
+            {
+                _logger.LogInformation("已完成，跳过");
+                return info;
+            }
+
+            //0需要领取
+            if (targetTask.state == 0)
+            {
+                _logger.LogInformation("开始领取任务");
+                await TryReceive(targetTask.task_code);
+            }
+
+            _logger.LogInformation("开始完成任务");
+            var re = await CompleteView(code);
+
+            //确认
+            if (re)
+            {
+                var infoResult = await _vipApi.GetTaskList();
+                if (infoResult.Code != 0) throw new Exception(infoResult.ToJsonStr());
+                info = infoResult.Data;
+                targetTask = GetTarget(info);
+
+                _logger.LogInformation("确认：{re}", targetTask.state == 3 && targetTask.complete_times >= 1);
+            }
+
+            CommonTaskItem GetTarget(VipTaskInfo info)
+            {
+                return info.Task_info.Modules.First(x => x.module_title == "日常任务")
+                    .common_task_item
+                    .First(x => x.task_code == "animatetab");
+            }
+
+            return info;
+        }
+
 
         /// <summary>
         /// 领取任务
@@ -582,5 +568,161 @@ namespace Ray.BiliBiliTool.Application
                 return false;
             }
         }
+
+        public async Task<bool> WatchBangumi()
+        {
+            if (_vipBigPointOptions.ViewBangumiList == null ||_vipBigPointOptions.ViewBangumiList.Count == 0)
+                return false;
+
+            long randomSsid = _vipBigPointOptions.ViewBangumiList[new Random().Next(0,_vipBigPointOptions.ViewBangumiList.Count)];
+
+            var res = await GetBangumi(randomSsid);
+            if (res is null)
+            {
+                return false;
+            }
+
+            var videoInfo = res.Value.Item1;
+            
+            // 随机播放时间
+            int playedTime = new Random().Next(905, 1800);
+            // 观看该视频
+            var request = new UploadVideoHeartbeatRequest()
+            {
+                Aid = long.Parse(videoInfo.Aid),
+                Bvid = videoInfo.Bvid,
+                Cid = videoInfo.Cid,
+                Mid = long.Parse(_biliCookie.UserId),
+                Sid = randomSsid,
+                Epid = res.Value.Item2,
+                Csrf = _biliCookie.BiliJct,
+                Type = 4,
+                Sub_type = 1,
+                Start_ts = DateTime.Now.ToTimeStamp() - playedTime,
+                Played_time = playedTime,
+                Realtime = playedTime,
+                Real_played_time = playedTime
+            };
+            BiliApiResponse apiResponse = await _videoApi.UploadVideoHeartbeat(request);
+            if (apiResponse.Code == 0)
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// 从自定义的番剧ssid中选择其中的一部中的一集
+        /// </summary>
+        /// <param name="randomSsid">番剧ssid</param>
+        /// <returns></returns>
+        private async Task<(VideoInfoDto,long)?> GetBangumi(long randomSsid)
+        {
+            try
+            {
+                if (randomSsid is 0 or long.MinValue)
+                    return null;
+                var bangumiInfo = await _videoApi.GetBangumiBySsid(randomSsid);
+
+                // 从获取的剧集中随机获得其中的一集
+
+                var bangumi = bangumiInfo.Result.episodes[new Random().Next(0, bangumiInfo.Result.episodes.Count)];
+                var videoInfo = new VideoInfoDto()
+                {
+                    Bvid = bangumi.bvid,
+                    Aid = bangumi.aid.ToString(),
+                    Cid = bangumi.cid,
+                    Copyright = 1,
+                    Duration = bangumi.duration,
+                    Title = bangumi.share_copy
+                };
+                _logger.LogInformation("本次播放的正片为：{title}",bangumi.share_copy);
+                return (videoInfo, bangumi.ep_id);
+            }
+            catch (Exception e)
+            {
+                _logger.LogError(e.Message);   
+            }
+            return null;
+        }
+        #region deprecated
+        [TaskInterceptor("浏览影视频道页10秒", TaskLevel.Two, false)]
+        private async Task<VipTaskInfo> ViewFilmChannel(VipTaskInfo info)
+        {
+            var code = "tv_channel";
+
+            CommonTaskItem targetTask = GetTarget(info);
+
+            //如果状态不等于3，则做
+            if (targetTask.state == 3)
+            {
+                _logger.LogInformation("已完成，跳过");
+                return info;
+            }
+
+            //0需要领取
+            if (targetTask.state == 0)
+            {
+                _logger.LogInformation("开始领取任务");
+                await TryReceive(targetTask.task_code);
+            }
+
+            _logger.LogInformation("开始完成任务");
+            var re = await CompleteView(code);
+
+            //确认
+            if (re)
+            {
+                var infoResult = await _vipApi.GetTaskList();
+                if (infoResult.Code != 0) throw new Exception(infoResult.ToJsonStr());
+                info = infoResult.Data;
+                targetTask = GetTarget(info);
+
+                _logger.LogInformation("确认：{re}", targetTask.state == 3 && targetTask.complete_times >= 1);
+            }
+
+            CommonTaskItem GetTarget(VipTaskInfo info)
+            {
+                return info.Task_info.Modules.First(x => x.module_title == "日常任务")
+                    .common_task_item
+                    .First(x => x.task_code == "filmtab");
+            }
+
+            return info;
+        }
+
+        [TaskInterceptor("购买指定大会员产品（仅领取）", TaskLevel.Two, false)]
+        private async Task<VipTaskInfo> BuyVipProduct(VipTaskInfo info)
+        {
+            CommonTaskItem targetTask = GetTarget(info);
+
+            if (targetTask.state is 3 or 1)
+            {
+                var re = targetTask.state == 1 ? "已领取" : "已完成";
+                _logger.LogInformation("{re}，跳过", re);
+                return info;
+            }
+
+            //0需要领取
+            if (targetTask.state == 0)
+            {
+                _logger.LogInformation("开始领取任务");
+                await TryReceive(targetTask.task_code);
+            }
+
+            return info;
+
+            CommonTaskItem GetTarget(VipTaskInfo info)
+            {
+                return info.Task_info.Modules.First(x => x.module_title == "日常任务")
+                    .common_task_item
+                    .First(x => x.task_code == "subscribe");
+            }
+        }
+
+
+        #endregion
+
     }
 }

--- a/src/Ray.BiliBiliTool.Application/VipBigPointAppService.cs
+++ b/src/Ray.BiliBiliTool.Application/VipBigPointAppService.cs
@@ -287,7 +287,7 @@ namespace Ray.BiliBiliTool.Application
         [TaskInterceptor("浏览追番频道页10秒", TaskLevel.Two, false)]
         private async Task<VipTaskInfo> ViewAnimate(VipTaskInfo info)
         {
-            var code = "dress-view";
+            var code = "jp_channel";
 
             CommonTaskItem targetTask = GetTarget(info);
 
@@ -304,7 +304,7 @@ namespace Ray.BiliBiliTool.Application
                 _logger.LogInformation("开始领取任务");
                 await TryReceive(targetTask.task_code);
             }
-
+            
             _logger.LogInformation("开始完成任务");
             var re = await CompleteView(code);
 
@@ -323,7 +323,7 @@ namespace Ray.BiliBiliTool.Application
             {
                 return info.Task_info.Modules.First(x => x.module_title == "日常任务")
                     .common_task_item
-                    .First(x => x.task_code == "dress-view");
+                    .First(x => x.task_code == "animatetab");
             }
 
             return info;
@@ -496,7 +496,7 @@ namespace Ray.BiliBiliTool.Application
             }
 
             _logger.LogInformation("开始完成任务");
-            var re = await CompleteView(code);
+            var re = await Complete(code);
 
             //确认
             if (re)

--- a/src/Ray.BiliBiliTool.Application/VipBigPointAppService.cs
+++ b/src/Ray.BiliBiliTool.Application/VipBigPointAppService.cs
@@ -513,7 +513,7 @@ namespace Ray.BiliBiliTool.Application
             {
                 return info.Task_info.Modules.First(x => x.module_title == "日常任务")
                     .common_task_item
-                    .First(x => x.task_code == "animatetab");
+                    .First(x => x.task_code == "dress-view");
             }
 
             return info;

--- a/src/Ray.BiliBiliTool.Application/VipBigPointAppService.cs
+++ b/src/Ray.BiliBiliTool.Application/VipBigPointAppService.cs
@@ -151,6 +151,8 @@ namespace Ray.BiliBiliTool.Application
             //观看任意正片内容
             taskInfo = await ViewVideo(taskInfo);
 
+            
+
             //领取购买任务
             taskInfo = await BuyVipVideo(taskInfo);
             // taskInfo = await BuyVipProduct(taskInfo);
@@ -393,6 +395,14 @@ namespace Ray.BiliBiliTool.Application
             }
 
             _logger.LogInformation("开始完成任务");
+            _logger.LogInformation("观看第一个正片内容");
+
+            await WatchBangumi();
+
+            _logger.LogInformation("观看第二个正片内容");
+
+            //等待40s
+            await Task.Delay(TimeSpan.FromSeconds(40));
 
             await WatchBangumi();
 

--- a/src/Ray.BiliBiliTool.Config/Extensions/ServiceCollectionExtension.cs
+++ b/src/Ray.BiliBiliTool.Config/Extensions/ServiceCollectionExtension.cs
@@ -23,6 +23,7 @@ namespace Ray.BiliBiliTool.Config.Extensions
                 .Configure<DailyTaskOptions>(configuration.GetSection("DailyTaskConfig"))
                 .Configure<LiveLotteryTaskOptions>(configuration.GetSection("LiveLotteryTaskConfig"))
                 .Configure<UnfollowBatchedTaskOptions>(configuration.GetSection("UnfollowBatchedTaskConfig"))
+                .Configure<VipBigPointOptions>(configuration.GetSection("VipBigPointConfig"))
                 .Configure<SecurityOptions>(configuration.GetSection("Security"))
                 .Configure<ReceiveVipPrivilegeOptions>(configuration.GetSection("ReceiveVipPrivilegeConfig"))
                 .Configure<LiveFansMedalTaskOptions>(configuration.GetSection("LiveFansMedalTaskOptions"))

--- a/src/Ray.BiliBiliTool.Config/Options/VipBigPointOptions.cs
+++ b/src/Ray.BiliBiliTool.Config/Options/VipBigPointOptions.cs
@@ -1,0 +1,28 @@
+﻿using System.Collections.Generic;
+
+namespace Ray.BiliBiliTool.Config.Options;
+
+public class VipBigPointOptions
+{
+    public string ViewBangumis { get; set; }
+
+    public List<long> ViewBangumiList
+    {
+        get
+        {
+            List<long> re = new();
+            if (string.IsNullOrWhiteSpace(ViewBangumis) | ViewBangumis == "-1")
+                return re;
+
+            string[] array = ViewBangumis.Split(',');
+            foreach (string item in array)
+            {
+                if (long.TryParse(item.Trim(), out long upId))
+                    re.Add(upId);
+                else
+                    re.Add(long.MinValue);
+            }
+            return re;
+        }
+    }
+}

--- a/src/Ray.BiliBiliTool.Console/appsettings.Development.json
+++ b/src/Ray.BiliBiliTool.Console/appsettings.Development.json
@@ -1,6 +1,6 @@
 {
   "DailyTaskConfig": {
-    "SupportUpIds": "",
+    "SupportUpIds": "499290501",
     "AutoChargeUpId": "220893216"
   },
   "Security": {

--- a/src/Ray.BiliBiliTool.Console/appsettings.Development.json
+++ b/src/Ray.BiliBiliTool.Console/appsettings.Development.json
@@ -1,6 +1,6 @@
 {
   "DailyTaskConfig": {
-    "SupportUpIds": "499290501",
+    "SupportUpIds": "",
     "AutoChargeUpId": "220893216"
   },
   "Security": {

--- a/src/Ray.BiliBiliTool.Console/appsettings.json
+++ b/src/Ray.BiliBiliTool.Console/appsettings.json
@@ -38,7 +38,8 @@
   },
 
   "VipBigPointConfig": {
-    "Cron": "7 1 * * *"
+    "Cron": "7 1 * * *",
+    "ViewBangumis": "33378" // 自定义番剧的ssid，若不清楚含义请勿修改（默认为名侦探柯南）
   },
 
   "LiveFansMedalTaskConfig": {

--- a/src/Ray.BiliBiliTool.Console/appsettings.json
+++ b/src/Ray.BiliBiliTool.Console/appsettings.json
@@ -6,7 +6,7 @@
     "Cron": "0 15 * * *",
     "IsWatchVideo": true, //是否观看视频
     "IsShareVideo": true, //是否分享视频
-    "IsDonateCoinForArticle": false,
+    "IsDonateCoinForArticle": true,
     "NumberOfCoins": 5, //每日设定的投币数 [0,5]
     "NumberOfProtectedCoins": 0, // 要保留的硬币数量 [0,int_max]，0 为不保留，int_max 通常取 (2^31)-1
     "SaveCoinsWhenLv6": false, //达到六级后是否开始白嫖[false,true]

--- a/src/Ray.BiliBiliTool.Console/appsettings.json
+++ b/src/Ray.BiliBiliTool.Console/appsettings.json
@@ -6,7 +6,7 @@
     "Cron": "0 15 * * *",
     "IsWatchVideo": true, //是否观看视频
     "IsShareVideo": true, //是否分享视频
-    "IsDonateCoinForArticle": true,
+    "IsDonateCoinForArticle": false,
     "NumberOfCoins": 5, //每日设定的投币数 [0,5]
     "NumberOfProtectedCoins": 0, // 要保留的硬币数量 [0,int_max]，0 为不保留，int_max 通常取 (2^31)-1
     "SaveCoinsWhenLv6": false, //达到六级后是否开始白嫖[false,true]

--- a/src/Ray.BiliBiliTool.DomainService/ArticleDomainService.cs
+++ b/src/Ray.BiliBiliTool.DomainService/ArticleDomainService.cs
@@ -54,7 +54,6 @@ public class ArticleDomainService : IArticleDomainService
     }
 
 
-
     public async Task LikeArticle(long cvid)
     {
         await _articleApi.Like(cvid, _biliCookie.BiliJct);
@@ -66,7 +65,6 @@ public class ArticleDomainService : IArticleDomainService
     /// <returns></returns>
     public async Task<bool> AddCoinForArticles()
     {
-        
         var donateCoinsCounts = await CalculateDonateCoinsCounts();
 
         if (donateCoinsCounts == 0)
@@ -84,11 +82,17 @@ public class ArticleDomainService : IArticleDomainService
             _logger.LogDebug("开始尝试第{num}次", i);
 
             var upId = GetUpFromConfigUps();
-            var cvid = await GetRandomArticleFromUp(upId);
-            if (upId == 0 || cvid == 0)
+            if (upId == 0)
             {
-                _logger.LogInformation("未添加支持的Up主，任务跳过");
-                return false;
+                _logger.LogDebug("未能成功选择支持的Up主");
+                continue;
+            }
+            // 当upId不符合时，会直接报错，需要将两者的判断分隔开
+            var cvid = await GetRandomArticleFromUp(upId);
+            if (cvid == 0)
+            {
+                _logger.LogDebug("第{num}次尝试，未能成功选择合适的专栏",i);
+                continue;
             }
 
             if (await AddCoinForArticle(cvid, upId))
@@ -97,12 +101,11 @@ public class ArticleDomainService : IArticleDomainService
                 if (_dailyTaskOptions.SelectLike)
                 {
                     await LikeArticle(cvid);
-                    _logger.LogInformation("文章点赞成功");
+                    _logger.LogInformation("专栏点赞成功");
                 }
+
                 success++;
             }
-
-                
         }
 
         if (success == donateCoinsCounts)
@@ -112,14 +115,14 @@ public class ArticleDomainService : IArticleDomainService
             _logger.LogInformation("投币尝试超过10次，已终止");
             return false;
         }
-            
+
 
         _logger.LogInformation("【硬币余额】{coin}", (await _accountApi.GetCoinBalance()).Data.Money ?? 0);
 
         return true;
     }
 
-    
+
     /// <summary>
     /// 给某一篇专栏投币
     /// </summary>
@@ -200,7 +203,7 @@ public class ArticleDomainService : IArticleDomainService
 
         ArticleInfo articleInfo = re.Data.Articles.FirstOrDefault();
 
-        _logger.LogDebug("获取到的专栏{cvid}({title})", articleInfo.Id, articleInfo.Title);
+        _logger.LogInformation("获取到的专栏{cvid}({title})", articleInfo.Id, articleInfo.Title);
 
         // 检查是否可投
         if (!await IsCanDonate(articleInfo.Id))
@@ -236,7 +239,8 @@ public class ArticleDomainService : IArticleDomainService
                 _logger.LogDebug("不能为自己投币");
                 return 0;
             }
-            _logger.LogDebug("挑选出的up主为{UpId}",randomUpId);
+
+            _logger.LogDebug("挑选出的up主为{UpId}", randomUpId);
             return randomUpId;
         }
         catch (Exception e)

--- a/src/Ray.BiliBiliTool.DomainService/ArticleDomainService.cs
+++ b/src/Ray.BiliBiliTool.DomainService/ArticleDomainService.cs
@@ -179,17 +179,17 @@ public class ArticleDomainService : IArticleDomainService
 
         var req = new SearchArticlesByUpIdDto()
         {
-            Mid = mid,
-            Ps = 1,
-            Pn = new Random().Next(1, articleCount + 1)
+            mid = mid,
+            ps = 1,
+            pn = new Random().Next(1, articleCount + 1)
         };
         var w_ridDto = await _wbiDomainService.GetWridAsync(req);
 
         var fullDto = new SearchArticlesByUpIdFullDto()
         {
-            Mid = mid,
-            Ps = req.Ps,
-            Pn = req.Pn,
+            mid = mid,
+            ps = req.ps,
+            pn = req.pn,
             w_rid = w_ridDto.w_rid,
             wts = w_ridDto.wts
         };
@@ -261,14 +261,14 @@ public class ArticleDomainService : IArticleDomainService
     {
         var req = new SearchArticlesByUpIdDto()
         {
-            Mid = mid
+            mid = mid
         };
 
         var w_ridDto = await _wbiDomainService.GetWridAsync(req);
 
         var fullDto = new SearchArticlesByUpIdFullDto()
         {
-            Mid = mid,
+            mid = mid,
             w_rid = w_ridDto.w_rid,
             wts = w_ridDto.wts
         };

--- a/test/AppServiceTest/VipServiceTest.cs
+++ b/test/AppServiceTest/VipServiceTest.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using Ray.BiliBiliTool.Application.Contracts;
+using Ray.BiliBiliTool.DomainService.Dtos;
 using Ray.BiliBiliTool.Infrastructure;
 
 namespace AppServiceTest;
@@ -17,5 +18,15 @@ public class VipServiceTest
         using var scope = Global.ServiceProviderRoot.CreateScope();
         var appService = scope.ServiceProvider.GetRequiredService<IVipBigPointAppService>();
         await appService.VipExpress();
+    }
+
+    [Fact]
+    public async Task WatchVideo()
+    {
+        using var scope = Global.ServiceProviderRoot.CreateScope();
+        var appService = scope.ServiceProvider.GetRequiredService<IVipBigPointAppService>();
+        var res = await appService.WatchBangumi();
+        Assert.Equal(true,res);
+
     }
 }

--- a/test/AppServiceTest/VipServiceTest.cs
+++ b/test/AppServiceTest/VipServiceTest.cs
@@ -26,7 +26,7 @@ public class VipServiceTest
         using var scope = Global.ServiceProviderRoot.CreateScope();
         var appService = scope.ServiceProvider.GetRequiredService<IVipBigPointAppService>();
         var res = await appService.WatchBangumi();
-        Assert.Equal(true,res);
-
+        Assert.True(res);
+         
     }
 }

--- a/test/BiliAgentTest/VideoApiTest.cs
+++ b/test/BiliAgentTest/VideoApiTest.cs
@@ -17,7 +17,7 @@ namespace BiliAgentTest
     {
         public VideoApiTest()
         {
-            Program.CreateHost(new[] { "--ENVIRONMENT=Development" });//Ä¬ÈÏPrd»·¾³£¬ÕâÀïÖ¸¶¨ÎªDevºó£¬¿ÉÒÔ¶ÁÈ¡µ½ÓÃ»§»úÃÜÅäÖÃ
+            Program.CreateHost(new[] { "--ENVIRONMENT=Development" });//Ä¬ï¿½ï¿½Prdï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Ö¸ï¿½ï¿½ÎªDevï¿½ó£¬¿ï¿½ï¿½Ô¶ï¿½È¡ï¿½ï¿½ï¿½Ã»ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
         }
 
         [Fact]
@@ -39,6 +39,19 @@ namespace BiliAgentTest
             {
                 Assert.False(re.Code != 0);
             }
+        }
+
+        [Fact]
+        public async Task GetBangumiTest()
+        {
+
+            using var scope = Global.ServiceProviderRoot.CreateScope();
+
+            var ck = scope.ServiceProvider.GetRequiredService<CookieStrFactory>();
+            var api = scope.ServiceProvider.GetRequiredService<IVideoApi>();
+            var req = await api.GetBangumiBySsid(46508);
+
+            Assert.Equal(0,req.Code);
         }
     }
 }

--- a/test/BiliAgentTest/VipApiTest.cs
+++ b/test/BiliAgentTest/VipApiTest.cs
@@ -7,6 +7,9 @@ using Ray.BiliBiliTool.Console;
 using Ray.BiliBiliTool.Infrastructure;
 using Ray.BiliBiliTool.Agent.BiliBiliAgent.Interfaces;
 using Xunit.Abstractions;
+using System;
+using Ray.BiliBiliTool.Agent.BiliBiliAgent.Dtos.ViewMall;
+
 namespace BiliAgentTest;
 
 public class VipApiTest
@@ -16,6 +19,22 @@ public class VipApiTest
     {
         _output = output;
         Program.CreateHost(new[] { "--ENVIRONMENT=Development" });
+    }
+
+    [Fact]
+    public async Task SignTaskTest()
+    {
+        using var scope = Global.ServiceProviderRoot.CreateScope();
+
+        var ck = scope.ServiceProvider.GetRequiredService<BiliCookie>();
+        var api = scope.ServiceProvider.GetRequiredService<IVipBigPointApi>();
+
+        var re = await api.Sign(new SignRequest()
+        {
+            // Csrf = ck.BiliJct
+        });
+        _output.WriteLine(re.ToJsonStr());
+        Assert.Equal(0, re.Code);
     }
 
     [Fact]
@@ -55,5 +74,22 @@ public class VipApiTest
         });
 
         _output.WriteLine(re.Message);
+    }
+
+    [Fact]
+    public async Task ViewVipMallTest()
+    {
+        using var scope = Global.ServiceProviderRoot.CreateScope();
+
+        var ck = scope.ServiceProvider.GetRequiredService<BiliCookie>();
+        var api = scope.ServiceProvider.GetRequiredService<IVipMallApi>();
+        // var test = await api.ViewvipMall("{\r\n\"csrf\":\"33e5d4564b6b69cb4ed829bc404158cb\",\r\n\"eventId\":\"hevent_oy4b7h3epeb\"\r\n}");
+        var re = await api.ViewVipMall(new ViewVipMallRequest()
+        {
+            Csrf = ck.BiliJct,
+            EventId = "hevent_oy4b7h3epeb"
+        });
+        _output.WriteLine(re.Message);
+        
     }
 }

--- a/test/BiliAgentTest/VipApiTest.cs
+++ b/test/BiliAgentTest/VipApiTest.cs
@@ -92,4 +92,16 @@ public class VipApiTest
         _output.WriteLine(re.Message);
         
     }
+
+    [Fact]
+    public async Task DressViewTest()
+    {
+        using var scope = Global.ServiceProviderRoot.CreateScope();
+
+        var ck = scope.ServiceProvider.GetRequiredService<BiliCookie>();
+        var api = scope.ServiceProvider.GetRequiredService<IVipBigPointApi>();
+        var re = await api.Complete(new ReceiveOrCompleteTaskRequest(
+            "dress-view"));
+        _output.WriteLine(re.Message);
+    }
 }


### PR DESCRIPTION
<!-- 该操作会向作者源仓库发起PR，是用来向源仓库贡献自己代码的 -->
<!-- 请PR到我的develop分支上，main分支不接受直接PR -->

<!-- 如果您明白正在做什么，请将下一行中符号【】内的文字由“no”修改为“yes”（不含引号） -->
<!-- 请问您是否明白：【yes】 -->

## 修复错误：

- 修复了在专栏投币任务中错误的return导致不能完成预期投币任务的问题
- 修复专栏投币任务中查询up主专栏时出现权限不足的问题

## 添加功能：
添加的功能如标题所示。

目前大积分相关任务中除了需要购买的任务外都已实现

注意：
浏览会员购的api是从https://github.com/catlair/BiliOutils的源码看到的，对于api使用可能是存在问题的，但目前运行正常。

## 添加配置项：

新增了配置项`ViewBangumis`用于指定在完成观看正片内容任务时观看的番剧

注意：
1. 目前该配置只支持使用番剧的ssid，预计后续改为使用mdid
2. 当前指定的番剧为名侦探柯南，解析json的时候由于其集数太多，在debug会使用大概20M的内存，计划找几个合适的番剧
3. 允许添加多个番剧

```
"VipBigPointConfig": {
  "Cron": "7 1 * * *",
  "ViewBangumis": "33378" // 自定义番剧的ssid，若不清楚含义请勿修改（默认为名侦探柯南）
},
```
## 更新文档
1. 为影响专栏投币的配置添加相关描述
2. 增添对新增配置的相关描述

**大会员相关任务有问题的尽量在最近一个月内提出，一个月后大会员就过期了 o(TヘTo)**
