### PR TITLE
直播亲密度获取规则修改

### DIFF
--- a/src/Ray.BiliBiliTool.Agent/BiliBiliAgent/Dtos/Live/GetLiveRoomInfoResponse.cs
+++ b/src/Ray.BiliBiliTool.Agent/BiliBiliAgent/Dtos/Live/GetLiveRoomInfoResponse.cs
@@ -14,6 +14,8 @@ namespace Ray.BiliBiliTool.Agent.BiliBiliAgent.Dtos.Live
 
         public long Parent_area_id { get; set; }
 
+        public int Live_Status { get; set; }
+
         public long Uid { get; set; }
     }
 }

--- a/src/Ray.BiliBiliTool.Config/Options/LiveFansMedalTaskOptions.cs
+++ b/src/Ray.BiliBiliTool.Config/Options/LiveFansMedalTaskOptions.cs
@@ -35,5 +35,24 @@ namespace Ray.BiliBiliTool.Config.Options
         //public const string UserAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/108.0.0.0 Safari/537.36";
 
         public const int HeartBeatInterval = 60;
+
+        /// <summary>
+        /// 点赞次数
+        /// </summary>
+        public int LikeNumber { get; set; } = 55;
+
+        /// <summary>
+        /// 点赞发送失败多少次时放弃
+        /// </summary>
+        public int LikeGiveUpThreshold { get; set; } = 5;
+
+        /// <summary>
+        /// 发送弹幕次数
+        /// </summary>
+        public int SendDanmakuNumber { get; set; } = 15;
+        /// <summary>
+        /// 弹幕发送失败多少次时放弃
+        /// </summary>
+        public int SendDanmakugiveUpThreshold { get; set; } = 5;
     }
 }


### PR DESCRIPTION
<!-- 请详细描述你要PR的内容 -->

### 内容

根据 #751 中所提，B站修改了直播亲密度获取规则。

- 修改弹幕发送为总共发送15条每一个直播间
- ~~修改点赞直播间为点赞55次每一个直播间，自动跳过未开播的直播间~~

### 仍然存在的问题

- 发送心跳包挂机直播间功能目前暂不能使用（发送成功但不能记录）
- ~~直播间点赞可能需要处于开播的直播间，目前确定未开播的直播间点赞不能加亲密度。~~ 已确定点赞暂时失效。

当前抓到的点赞的接口`https://api.live.bilibili.com/xlive/app-ucenter/v1/like_info_v3/like/likeReportV3`
必须参数：
```
actionKey:appkey
appkey:1d8b6e7d45233436
click_time:10
room_id:xxx
uid:xxx
access_key:xxx
anchor_id:xxx（不知道来源）
```



也就是说目前如果在未开播时运行脚本，一个牌子最多获得70点亲密度。 (ﾟДﾟ*)ﾉ
