### PR TITLE
主要兼容性建议

### DIFF
--- a/qinglong/DefaultTasks/bili_task_base.sh
+++ b/qinglong/DefaultTasks/bili_task_base.sh
@@ -14,8 +14,8 @@ verbose=false                          # 开启debug日志
 #bili_repo="raywangqvq/bilibilitoolpro" # 仓库地址 输入官方分支，或者加速分支目录
 # 针对使用fock拉取分支的情况，建议把bili_repo做在环境变量中可以修改调整
 # 可更兼容性
-#bili_repo="aspnmy/BiliBiliToolPro"
-bili_repo=${BILI_TRUETRUE_REPONAME:-"raywangqvq/bilibilitoolpro"}
+
+bili_repo=${BILI_TRUEUSE_NAME:-"raywangqvq/bilibilitoolpro"}
 bili_branch=""                         # 分支名，空或_develop
 prefer_mode=${BILI_MODE:-""}     # dotnet或bilitool，需要通过环境变量配置
 github_proxy=${BILI_GITHUB_PROXY:-""}  # 下载github release包时使用的代理，会拼在地址前面，需要通过环境变量配置
@@ -92,7 +92,6 @@ say "青龙repo目录: $dir_repo"
 qinglong_bili_repo="$(echo "$bili_repo" | sed 's/\//_/g')${bili_branch}"
 
 qinglong_bili_repo_dir="$(find $dir_repo -type d \( -iname $qinglong_bili_repo -o -iname ${qinglong_bili_repo}_main \) | head -1)"
-#qinglong_bili_repo_dir="$qinglong_bili_repo/podAdmin_BiliBiliToolPro"
 
 say "bili仓库目录: $qinglong_bili_repo_dir"
 
@@ -396,23 +395,6 @@ install_dotnet() {
 get_download_url() {
     eval $invocation
     # 增加业务逻辑：主要为了解决完成抓不到版本号时造成的更新错误
-    # 可配置环境变量，自定义一个初始值，然后进行下载，避免因为返回值为null而下载不了安装包
-    # bilitool: tag.txt记录的版本：null
-    # bilitool: bilitool未安装
-    # bilitool: 开始安装环境
-    # bilitool: 开始安装bilitool
-    # bilitool: 最新版本：null
-    # bilitool: 下载地址：https://ghproxy.net/https://github.com/RayWangQvQ/BiliBiliToolPro/releases/download/null/bilibili-tool-pro-vnull-linux-musl-x64.zip
-    # % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
-    #                                 Dload  Upload   Total   Spent    Left  Speed
-    # 100     9  100     9    0     0     10      0 --:--:-- --:--:-- --:--:--    10
-    # Archive:  bilitool-null.zip
-    # End-of-central-directory signature not found.  Either this file is not
-    # a zipfile, or it constitutes one disk of a multi-part archive.  In the
-    # latter case the central directory and zipfile comment will be found on
-    # the last disk(s) of this archive.
-    # unzip:  cannot find zipfile directory in one of bilitool-null.zip or
-    #         bilitool-null.zip.zip, and cannot find bilitool-null.zip.ZIP, period.
 
     tag=${BILI_STORED_TAG:-""}
     url="${github_proxy}https://github.com/RayWangQvQ/BiliBiliToolPro/releases/download/$tag/bilibili-tool-pro-v$tag-$current_os-$machine_architecture.zip"


### PR DESCRIPTION
<!-- 请详细描述你要PR的内容 -->
### 1、建议把部分变量改成全局变量增加兼容性
https://github.com/RayWangQvQ/BiliBiliToolPro/issues/781
### 2、增加业务逻辑：主要为了解决完成抓不到版本号时造成的更新错误  ，提高兼容性
    + 错误复现如下
    # 可配置环境变量，自定义一个初始值，然后进行下载，避免因为返回值为null而下载不了安装包
    # bilitool: tag.txt记录的版本：null
    # bilitool: bilitool未安装
    # bilitool: 开始安装环境
    # bilitool: 开始安装bilitool
    # bilitool: 最新版本：null
    # bilitool: 下载地址：https://ghproxy.net/https://github.com/RayWangQvQ/BiliBiliToolPro/releases/download/null/bilibili-tool-pro-vnull-linux-musl-x64.zip
    # % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
    #                                 Dload  Upload   Total   Spent    Left  Speed
    # 100     9  100     9    0     0     10      0 --:--:-- --:--:-- --:--:--    10
    # Archive:  bilitool-null.zip
    # End-of-central-directory signature not found.  Either this file is not
    # a zipfile, or it constitutes one disk of a multi-part archive.  In the
    # latter case the central directory and zipfile comment will be found on
    # the last disk(s) of this archive.
    # unzip:  cannot find zipfile directory in one of bilitool-null.zip or
    #         bilitool-null.zip.zip, and cannot find bilitool-null.zip.ZIP, period.
<请描述您将贡献的内容>
