### PR TITLE
添加推送到邮箱的支持

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -763,8 +763,6 @@ webhook的完整地址，在Teams的Channel中获取，详细获取方式请参�
 | 默认值   | 空                                |
 | 命令行示范 |                                  |
 
-<a id="markdown-38-日志相关" name="38-日志相关"></a>
-
 <a id="markdown-3711-email" name="3711-推送到邮箱"></a>
 #### 3.7.11. 推送到邮箱
 官网：https://github.com/gutenye/email-notification/blob/main/src/templates/BiliBiliToolPro.md
@@ -790,7 +788,7 @@ webhook的完整地址，在Teams的Channel中获取，详细获取方式请参�
 | 默认值   | 空 |
 | 例子 ｜ BiliBiliToolPro\n#msg# ｜
 
-<a id="markdown-378-pushplus推荐" name="378-pushplus推荐"></a>
+<a id="markdown-38-日志相关" name="38-日志相关"></a>
 ### 3.8. 日志相关
 
 <a id="markdown-381-日志输出等级" name="381-日志输出等级"></a>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -765,12 +765,12 @@ webhook的完整地址，在Teams的Channel中获取，详细获取方式请参�
 
 <a id="markdown-38-日志相关" name="38-日志相关"></a>
 
-<a id="markdown-3710-email" name="3710-email"></a>
-#### 3.7.10. Email
+<a id="markdown-3711-email" name="3711-推送到邮箱"></a>
+#### 3.7.11. 推送到邮箱
 官网：https://github.com/gutenye/email-notification/blob/main/src/templates/BiliBiliToolPro.md
 
-<a id="markdown-37101-api" name="37101-api"></a>
-##### 3.7.10.1. api
+<a id="markdown-37111-api" name="37111-api"></a>
+##### 3.7.11.1. api
 
 |   TITLE   | CONTENT   |
 | ---------- | -------------- |
@@ -780,8 +780,8 @@ webhook的完整地址，在Teams的Channel中获取，详细获取方式请参�
 | 例子 | https://HOST/API_KEY }
 
 
-<a id="markdown-37102-bodyjsontemplate" name="37102-bodyjsontemplate"></a>
-##### 3.7.10.2. bodyJsonTemplate
+<a id="markdown-37112-bodyjsontemplate" name="37112-bodyjsontemplate"></a>
+##### 3.7.11.2. bodyJsonTemplate
 
 |   TITLE   | CONTENT   |
 | ---------- | -------------- |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -72,6 +72,9 @@
             - [3.7.10.1. 企业微信应用推送的corpId](#37101-企业微信应用推送的corpid)
             - [3.7.10.2. 企业微信应用推送的agentId](#37102-企业微信应用推送的agentid)
             - [3.7.10.3. 企业微信应用推送的secret](#37103-企业微信应用推送的secret)
+        - [3.7.11. 推送到邮箱](#3711-推送到邮箱)
+            - [3.7.11.1. api](#37111-api)
+            - [3.7.11.2. bodyJsonTemplate](#37112-bodyjsontemplate)
     - [3.8. 日志相关](#38-日志相关)
         - [3.8.1. 日志输出等级](#381-日志输出等级)
         - [3.8.2. 日志输出样式](#382-日志输出样式)
@@ -761,6 +764,33 @@ webhook的完整地址，在Teams的Channel中获取，详细获取方式请参�
 | 命令行示范 |                                  |
 
 <a id="markdown-38-日志相关" name="38-日志相关"></a>
+
+<a id="markdown-3710-email" name="3710-email"></a>
+#### 3.7.10. Email
+官网：https://github.com/gutenye/email-notification/blob/main/src/templates/BiliBiliToolPro.md
+
+<a id="markdown-37101-api" name="37101-api"></a>
+##### 3.7.10.1. api
+
+|   TITLE   | CONTENT   |
+| ---------- | -------------- |
+| 配置Key | `Serilog__WriteTo__8__Args__api` |
+| 值域   | 一串字符串 |
+| 默认值   | 空 |
+| 例子 | https://HOST/API_KEY }
+
+
+<a id="markdown-37102-bodyjsontemplate" name="37102-bodyjsontemplate"></a>
+##### 3.7.10.2. bodyJsonTemplate
+
+|   TITLE   | CONTENT   |
+| ---------- | -------------- |
+| 配置Key | `Serilog__WriteTo__8__Args__bodyJsonTemplate` |
+| 值域   | 一串字符串 |
+| 默认值   | 空 |
+| 例子 ｜ BiliBiliToolPro\n#msg# ｜
+
+<a id="markdown-378-pushplus推荐" name="378-pushplus推荐"></a>
 ### 3.8. 日志相关
 
 <a id="markdown-381-日志输出等级" name="381-日志输出等级"></a>


### PR DESCRIPTION
添加通过邮箱推送通知的配置说明，包括API地址和请求体模板的配置项, 复用了自定义API, 但是支持邮箱通知

项目地址: https://github.com/gutenye/email-notification/blob/main/src/templates/BiliBiliToolPro.md