### PR TITLE
feat(daidai): 适配呆呆面板(Daidai Panel)

### DIFF
--- a/daidai/DefaultTasks/bili_task_base.sh
+++ b/daidai/DefaultTasks/bili_task_base.sh
@@ -1,0 +1,366 @@
+#!/usr/bin/env bash
+# cron:0 0 1 1 *
+# new Env("bili_base")
+
+# 呆呆面板（Daidai Panel）基础脚本。
+# 设计与 qinglong / baihu 的集成一致：每个面板只维护“自己这一份 base（环境安装部分）”，
+# 而 bili_task_daily.sh 等“各任务脚本”完全复用 qinglong 目录里的同名脚本——
+# 由订阅钩子 daidai/copyshfile.sh 在拉库后、建任务前从 qinglong/DefaultTasks 拷贝过来。
+# 所以本目录默认只放 base，不重复维护各任务脚本（详见 daidai/README.md）。
+#
+# 本 base 与 qinglong 版的差异只在“面板专属的运行环境安装/定位”：
+#   1. 用仓库根标记文件（Ray.BiliBiliTool.sln）向上查找仓库根目录，stable 与 dev 共用同一份 base；
+#   2. Ray_PlatformType 设为 DaiDai；登录后通过呆呆面板原生 Open API 写回 Cookie。
+
+# Stop script on NZEC
+set -e
+# Stop script if unbound variable found (use ${var:-} if intentional)
+set -u
+# By default cmd1 | cmd2 returns exit code of cmd2 regardless of cmd1 success
+set -o pipefail
+
+verbose=false                          # 开启debug日志
+bili_repo="raywangqvq/bilibilitoolpro" # 仓库地址（bilitool 模式下载 release 用）
+prefer_mode=${BILI_MODE:-"dotnet"}     # dotnet 或 bilitool，可通过面板环境变量 BILI_MODE 配置
+github_proxy=${BILI_GITHUB_PROXY:-""}  # 下载 github release 包时使用的代理，拼在地址前面
+export DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1 # 解决 ICU 相关抽风问题
+
+invocation='say_verbose "Calling: ${yellow:-}${FUNCNAME[0]} ${green:-}$*${normal:-}"'
+
+# 暴露 stream 3 作为函数内的“屏幕输出”，避免污染函数返回值
+exec 3>&1
+
+if [ -t 1 ] && command -v tput >/dev/null; then
+    ncolors=$(tput colors || echo 0)
+    if [ -n "$ncolors" ] && [ $ncolors -ge 8 ]; then
+        bold="$(tput bold || echo)"
+        normal="$(tput sgr0 || echo)"
+        red="$(tput setaf 1 || echo)"
+        green="$(tput setaf 2 || echo)"
+        yellow="$(tput setaf 3 || echo)"
+        cyan="$(tput setaf 6 || echo)"
+    fi
+fi
+
+say_warning() { printf "%b\n" "${yellow:-}bilitool: Warning: $1${normal:-}" >&3; }
+say_err() { printf "%b\n" "${red:-}bilitool: Error: $1${normal:-}" >&2; }
+say() { printf "%b\n" "${cyan:-}bilitool:${normal:-} $1" >&3; }
+say_verbose() { if [ "$verbose" = true ]; then say "$1"; fi; }
+
+# 尝试加载已安装 dotnet 的 PATH（官方脚本会把 PATH 写进 .bashrc）
+touch /root/.bashrc 2>/dev/null && . /root/.bashrc 2>/dev/null || true
+[ -f "$HOME/.bashrc" ] && . "$HOME/.bashrc" 2>/dev/null || true
+
+# 用仓库根标记文件向上查找仓库根目录：stable(DefaultTasks/) 与 dev(DefaultTasks/dev/)
+# 深度不同，但都能靠 Ray.BiliBiliTool.sln 这个根文件定位，从而共用同一份 base。
+find_repo_root() {
+    local dir="$1"
+    while [ "$dir" != "/" ] && [ -n "$dir" ]; do
+        if [ -f "$dir/Ray.BiliBiliTool.sln" ]; then
+            echo "$dir"
+            return 0
+        fi
+        dir="$(dirname "$dir")"
+    done
+    return 1
+}
+
+BILI_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+bilitool_repo_dir="$(find_repo_root "$BILI_SCRIPT_DIR" || true)"
+# 兜底：找不到标记文件时按目录层级回退（DefaultTasks/ 上跳两级）
+if [ -z "$bilitool_repo_dir" ]; then
+    bilitool_repo_dir="$(cd "$BILI_SCRIPT_DIR/../.." >/dev/null 2>&1 && pwd)"
+fi
+say "bilitool仓库目录: $bilitool_repo_dir"
+
+current_linux_os="debian"  # 或 alpine
+current_os="linux"         # 或 linux-musl
+machine_architecture="x64" # 或 arm、arm64
+
+bilitool_installed_version=0
+
+# 所有二进制相关操作都在仓库根的 bin 目录下执行
+cd "$bilitool_repo_dir"
+mkdir -p bin && cd "$bilitool_repo_dir/bin"
+
+machine_has() {
+    eval $invocation
+    command -v "$1" >/dev/null 2>&1
+    return $?
+}
+
+# 输出：arm、arm64、x64
+get_machine_architecture() {
+    eval $invocation
+    if command -v uname >/dev/null; then
+        CPUName=$(uname -m)
+        case $CPUName in
+        armv*l)
+            echo "arm"
+            return 0
+            ;;
+        aarch64 | arm64)
+            echo "arm64"
+            return 0
+            ;;
+        esac
+    fi
+    echo "x64"
+    return 0
+}
+
+get_linux_platform_name() {
+    eval $invocation
+    if [ -e /etc/os-release ]; then
+        . /etc/os-release
+        echo "$ID${VERSION_ID:+.${VERSION_ID}}"
+        return 0
+    fi
+    echo "Linux specific platform name and version could not be detected"
+    return 1
+}
+
+is_musl_based_distro() {
+    eval $invocation
+    (ldd --version 2>&1 || true) | grep -q musl
+}
+
+# 输出：linux、linux-musl
+get_current_os_name() {
+    eval $invocation
+    local uname=$(uname)
+    if [ "$uname" = "Linux" ]; then
+        if is_musl_based_distro; then
+            echo "linux-musl"
+            return 0
+        else
+            echo "linux"
+            return 0
+        fi
+    fi
+    say_err "OS name could not be detected: UName = $uname"
+    return 1
+}
+
+check_os() {
+    eval $invocation
+    current_os="$(get_current_os_name)"
+    say "当前系统：$current_os"
+
+    machine_architecture="$(get_machine_architecture)"
+    say "当前架构：$machine_architecture"
+
+    if [ "$current_os" = "linux" ]; then
+        current_linux_os="debian"
+        if ! machine_has curl; then
+            say "curl未安装，开始安装依赖..."
+            apt-get update && apt-get install -y curl
+        fi
+    else
+        current_linux_os="alpine"
+        if ! machine_has curl; then
+            say "curl未安装，开始安装依赖..."
+            apk update && apk add -y curl
+        fi
+    fi
+
+    say "当前选择的运行方式：$prefer_mode"
+}
+
+check_jq() {
+    if [ "$current_linux_os" = "debian" ]; then
+        machine_has jq || { say "安装jq..."; apt-get update && apt-get install -y jq; }
+    else
+        machine_has jq || { say "安装jq..."; apk update && apk add -y jq; }
+    fi
+}
+
+check_unzip() {
+    if [ "$current_linux_os" = "debian" ]; then
+        machine_has unzip || { say "安装unzip..."; apt-get update && apt-get install -y unzip; }
+    else
+        machine_has unzip || { say "安装unzip..."; apk update && apk add -y unzip; }
+    fi
+}
+
+check_dotnet() {
+    eval $invocation
+    dotnetVersion=$(dotnet --version)
+    say "当前dotnet版本：$dotnetVersion"
+    if [[ $(echo "$dotnetVersion" | grep -oE '^[0-9]+') -ge 8 ]]; then
+        say "已安装，且版本满足"
+        say "which dotnet: $(which dotnet)"
+        return 0
+    else
+        say "未安装"
+        return 1
+    fi
+}
+
+check_bilitool() {
+    eval $invocation
+    TAG_FILE="./tag.txt"
+    touch $TAG_FILE
+    local STORED_TAG=$(cat $TAG_FILE 2>/dev/null)
+    if [[ -z $STORED_TAG ]]; then
+        say "tag.txt为空，未安装过"
+        return 1
+    fi
+    say "tag.txt记录的版本：$STORED_TAG"
+    if [ -f "./Ray.BiliBiliTool.Console" ]; then
+        say "bilitool已安装"
+        bilitool_installed_version=$STORED_TAG
+        return 0
+    else
+        say "bilitool未安装"
+        return 1
+    fi
+}
+
+check_installed() {
+    eval $invocation
+    if [ "$prefer_mode" == "dotnet" ]; then
+        check_dotnet
+        return $?
+    fi
+    if [ "$prefer_mode" == "bilitool" ]; then
+        check_bilitool
+        return $?
+    fi
+    return 1
+}
+
+install_dotnet_by_script() {
+    eval $invocation
+    say "再尝试使用官方脚本安装"
+    curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel 8.0 --verbose
+
+    say "添加到PATH"
+    local exportFile="/root/.bashrc"
+    touch $exportFile
+    echo '' >>$exportFile
+    echo 'export DOTNET_ROOT=$HOME/.dotnet' >>$exportFile
+    echo 'export PATH=$PATH:$DOTNET_ROOT:$DOTNET_ROOT/tools' >>$exportFile
+    . $exportFile
+}
+
+install_dotnet() {
+    eval $invocation
+    say "开始安装dotnet"
+    say "当前系统：$current_linux_os"
+    if [[ $current_linux_os == "debian" ]]; then
+        say "使用apt安装"
+        if ! (curl -s -m 5 www.google.com >/dev/null); then
+            say "机器位于墙内，切换为国内镜像源"
+            cp /etc/apt/sources.list /etc/apt/sources.list.bak 2>/dev/null || true
+            sed -i 's/https:\/\/deb.debian.org/https:\/\/mirrors.ustc.edu.cn/g' /etc/apt/sources.list 2>/dev/null || true
+            sed -i 's/http:\/\/deb.debian.org/https:\/\/mirrors.ustc.edu.cn/g' /etc/apt/sources.list 2>/dev/null || true
+            apt-get update
+        fi
+        {
+            . /etc/os-release
+            curl -o packages-microsoft-prod.deb https://packages.microsoft.com/config/debian/$VERSION_ID/packages-microsoft-prod.deb
+            dpkg -i packages-microsoft-prod.deb
+            rm packages-microsoft-prod.deb
+            apt-get update && apt-get install -y dotnet-sdk-8.0
+        } || {
+            install_dotnet_by_script
+        }
+    else
+        say "使用apk安装"
+        if ! (curl -s -m 5 www.google.com >/dev/null); then
+            say "机器位于墙内，切换为国内镜像源"
+            cp /etc/apk/repositories /etc/apk/repositories.bak 2>/dev/null || true
+            sed -i 's/https:\/\/dl-cdn.alpinelinux.org/https:\/\/mirrors.ustc.edu.cn/g' /etc/apk/repositories 2>/dev/null || true
+            sed -i 's/http:\/\/dl-cdn.alpinelinux.org/https:\/\/mirrors.ustc.edu.cn/g' /etc/apk/repositories 2>/dev/null || true
+            apk update
+        fi
+        {
+            apk add dotnet8-sdk
+        } || {
+            install_dotnet_by_script
+        }
+    fi
+    dotnet --version && say "which dotnet: $(which dotnet)" && say "安装成功"
+    return $?
+}
+
+get_download_url() {
+    eval $invocation
+    tag=$1
+    url="${github_proxy}https://github.com/RayWangQvQ/BiliBiliToolPro/releases/download/$tag/bilibili-tool-pro-v$tag-$current_os-$machine_architecture.zip"
+    say "下载地址：$url"
+    echo $url
+    return 0
+}
+
+install_bilitool() {
+    eval $invocation
+    say "开始安装bilitool"
+    LATEST_RELEASE=$(curl -s https://api.github.com/repos/$bili_repo/releases/latest)
+    check_jq
+    LATEST_TAG=$(echo $LATEST_RELEASE | jq -r '.tag_name')
+    say "最新版本：$LATEST_TAG"
+
+    if [ "$LATEST_TAG" != "$bilitool_installed_version" ]; then
+        ASSET_URL=$(get_download_url $LATEST_TAG)
+        local zip_file_name="bilitool-$LATEST_TAG.zip"
+        curl -L -o "$zip_file_name" $ASSET_URL
+        check_unzip
+        unzip -jo "$zip_file_name" -d ./ &&
+            rm "$zip_file_name" &&
+            rm -f appsettings.*
+        echo $LATEST_TAG >./tag.txt
+    else
+        say "已经是最新版本，无需下载。"
+    fi
+}
+
+install() {
+    eval $invocation
+    if check_installed; then
+        say "环境正常，本次无需安装"
+    else
+        say "开始安装环境"
+        if [ "$prefer_mode" == "dotnet" ]; then
+            install_dotnet || {
+                say_err "安装失败，请根据文档自行在面板容器中安装dotnet，或切换为 bilitool 模式"
+                say_err "文档：https://github.com/RayWangQvQ/BiliBiliToolPro/blob/develop/daidai/README.md"
+            }
+        fi
+        if [ "$prefer_mode" == "bilitool" ]; then
+            install_bilitool || {
+                say_err "安装失败，请检查日志并重试，或切换为 dotnet 模式"
+                say_err "文档：https://github.com/RayWangQvQ/BiliBiliToolPro/blob/develop/daidai/README.md"
+            }
+        fi
+    fi
+}
+
+# 运行 bilitool 任务
+run_task() {
+    eval $invocation
+    local target_code=$1
+
+    export Ray_PlatformType=DaiDai
+    export Ray_RunTasks=$target_code
+
+    if [ "$prefer_mode" == "dotnet" ]; then
+        cd "$bilitool_repo_dir/src/Ray.BiliBiliTool.Console"
+        # 临时 props 文件压制编译告警，保持日志整洁，运行后删除
+        local props_file="$bilitool_repo_dir/Directory.Build.props"
+        local props_created=false
+        if [ ! -f "$props_file" ]; then
+            printf '<Project>\n  <PropertyGroup>\n    <NoWarn>$(NoWarn);NETSDK1188;CS9057;CS8618;CS9042;CS8625;CS8603;CS8602;CS8601;CS8600;CS8604</NoWarn>\n  </PropertyGroup>\n</Project>' >"$props_file"
+            props_created=true
+        fi
+        dotnet run -v m -- --ENVIRONMENT=Production
+        [ "$props_created" = true ] && rm -f "$props_file"
+    else
+        cd "$bilitool_repo_dir/bin"
+        chmod +x ./Ray.BiliBiliTool.Console && ./Ray.BiliBiliTool.Console --ENVIRONMENT=Production
+    fi
+}
+
+check_os
+install

--- a/daidai/DefaultTasks/dev/bili_dev_task_base.sh
+++ b/daidai/DefaultTasks/dev/bili_dev_task_base.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# cron:0 0 1 1 *
+# new Env("bili_dev_base")
+
+# 先行版(dev)任务脚本（bili_dev_task_*.sh，由 daidai/copyshfile.sh 从 qinglong 复用过来）
+# 会 source 本文件。这里不重复一份 base，直接复用上一级的 bili_task_base.sh——
+# 其仓库根目录定位用的是“向上找 Ray.BiliBiliTool.sln”，stable 与 dev 都适用。
+DEV_BASE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+. "$DEV_BASE_DIR/../bili_task_base.sh"

--- a/daidai/README.md
+++ b/daidai/README.md
@@ -1,0 +1,199 @@
+# 在呆呆面板（Daidai Panel）中运行
+
+[呆呆面板](https://github.com/linzixuanzz/daidai-panel) 是一款轻量、现代的定时任务管理面板（Go + Vue + SQLite），定位与青龙类似但更轻量。
+
+本目录提供 BiliBiliToolPro 在呆呆面板中运行的脚本与说明，整体思路与 [`qinglong/`](../qinglong/README.md)、[`baihu/`](../baihu/README.md) 一致：
+
+> 利用面板的「订阅管理」拉取本仓库源码，自动添加 cron 定时任务，然后在面板容器中安装 `dotnet` 环境或下载 `bilitool` 二进制包，定时运行相应的 Task。
+
+## 复用青龙脚本（与各面板保持一致的做法）
+
+各任务脚本（`bili_task_daily.sh` 等）的内容与青龙版**完全一致**——都只是 `. bili_task_base.sh; run_task "Xxx"`，与具体面板无关。所以本目录**不重复维护这些脚本**，而是：
+
+- `daidai/` 只保留一份**面板专属的 `bili_task_base.sh`**（负责呆呆面板下的运行环境安装与定位）；
+- 各任务脚本由订阅钩子 [`daidai/copyshfile.sh`](./copyshfile.sh) 在拉库后、建任务前，从 `qinglong/DefaultTasks` 复用拷贝过来；
+- `stable` 与 `dev` 共用同一份 base（靠仓库根标记文件 `Ray.BiliBiliTool.sln` 向上定位仓库根目录），进一步减少重复。
+
+这样后续青龙脚本有改动，呆呆面板自动跟随，不需要两边都改。
+
+> ⚠️ 适用范围：与青龙 / 白虎版一样，本方案面向 **Linux 容器形态的呆呆面板**（Docker / Magisk 模块），脚本依赖 `bash`。纯 Windows 单机版不适用。
+
+<!-- TOC -->
+
+- [1. 前置条件](#1-前置条件)
+- [2. 步骤](#2-步骤)
+  - [2.1. 新建 Open API 应用（拿 AppKey / AppSecret）](#21-新建-open-api-应用拿-appkey--appsecret)
+  - [2.2. 配置环境变量](#22-配置环境变量)
+  - [2.3. 添加订阅（拉库 + 钩子复用脚本 + 自动建任务）](#23-添加订阅拉库--钩子复用脚本--自动建任务)
+  - [2.4. 检查定时任务](#24-检查定时任务)
+  - [2.5. 扫码登录](#25-扫码登录)
+- [3. 运行模式：dotnet vs bilitool](#3-运行模式dotnet-vs-bilitool)
+- [4. 先行版（dev）](#4-先行版dev)
+- [5. GitHub 加速](#5-github-加速)
+- [6. 常见问题](#6-常见问题)
+
+<!-- /TOC -->
+
+## 1. 前置条件
+
+- 一个正常运行的 **呆呆面板**（推荐 Docker 部署，浏览器能正常打开面板）。
+- 面板能访问 GitHub（拉库、下载 dotnet / bilitool 需要）。国内网络见 [第 5 节 GitHub 加速](#5-github-加速)。
+
+呆呆面板默认就支持 `.sh` 脚本订阅、拉库后自动建任务、以及订阅「钩子脚本」，**无需像青龙那样改 `RepoFileExtensions` 配置**。
+
+## 2. 步骤
+
+### 2.1. 新建 Open API 应用（拿 AppKey / AppSecret）
+
+扫码登录成功后，需要有权限把 Cookie 写回面板的环境变量，所以先建一个 Open API 应用用于鉴权。
+
+面板 → **系统设置 → Open API** → 新建应用：
+
+```
+名称：bilitool
+授权范围（scopes）：envs        # 必须包含 envs（或填 * 全部授权）
+速率限制：留空或 0
+```
+
+创建后会显示 **AppKey** 和 **AppSecret**（AppSecret 只在创建/重置时完整显示一次，请先复制保存）。
+
+> 如果你不想自动写回 Cookie，可以跳过本步骤。登录任务会在日志里打印出 Cookie，你手动到「环境变量」里添加即可（见 [2.5](#25-扫码登录)）。
+
+### 2.2. 配置环境变量
+
+面板 → **环境变量** → 新建，添加下面两条（变量名照抄，注意是**双下划线** `__`）：
+
+| 变量名 | 值 | 说明 |
+| --- | --- | --- |
+| `DaiDaiConfig__AppKey` | 上一步的 AppKey | 必填 |
+| `DaiDaiConfig__AppSecret` | 上一步的 AppSecret | 必填 |
+
+可选变量：
+
+| 变量名 | 值 | 说明 |
+| --- | --- | --- |
+| `DaiDai_URL` | `http://127.0.0.1:5700` | 面板地址，**默认就是这个值**，一般不用填。只有改过面板端口、或在别的机器上跑 BiliBiliToolPro 时才需要填成面板实际可达地址（如 `http://192.168.1.10:5700`）。只要协议+主机+端口，不要带路径 |
+| `BILI_MODE` | `dotnet` 或 `bilitool` | 运行模式，默认 `dotnet`，见 [第 3 节](#3-运行模式dotnet-vs-bilitool) |
+| `BILI_GITHUB_PROXY` | 形如 `https://gh-proxy.com/` | 下载 bilitool 二进制时的 GitHub 加速前缀，仅 `bilitool` 模式用到 |
+
+> 多账号：本工具支持多个 B 站账号，每个账号一条 `Ray_BiliBiliCookies__0`、`Ray_BiliBiliCookies__1`…… 的环境变量。**这些 Cookie 变量由登录任务自动创建/更新，你不用手动建**。
+
+### 2.3. 添加订阅（拉库 + 钩子复用脚本 + 自动建任务）
+
+面板 → **订阅管理** → 新建订阅：
+
+```
+名称：Bilibili
+类型：Git 仓库（公开仓库）
+链接：https://github.com/RayWangQvQ/BiliBiliToolPro.git
+分支：develop
+定时类型：crontab
+定时规则：2 2 28 * *
+钩子脚本：bash daidai/copyshfile.sh
+白名单：bili_task_
+文件后缀：sh
+```
+
+> - **钩子脚本填 `bash daidai/copyshfile.sh`**：呆呆面板会在“拉库之后、自动建任务之前”执行它，把青龙目录里的各任务脚本复用到 `daidai/DefaultTasks`，并清理 `qinglong` 目录。这是各任务脚本能复用、不重复维护的关键。
+> - **白名单填 `bili_task_`**：只把 `bili_task_*.sh` 登记成定时任务，不会把仓库里其他文件也建成任务。
+> - **不要**限制「指定子目录」：钩子需要 `qinglong/` 源、`dotnet` 模式需要编译 `src/` 源码，都要求拉取完整仓库。
+> - 没提到的选项保持默认即可（自动添加任务、自动同步默认是开的）。
+> - 呆呆面板适配目前在 `develop`（先行版）分支，所以**分支填 `develop`**；等合并进 `main` 后可改回 `main`。
+
+保存后点「运行」拉库。日志里会先看到 `[执行订阅钩子]`（同步脚本），再看到自动扫描 `# cron:` / `# new Env("...")` 并**自动创建 bilibili 定时任务**。
+
+### 2.4. 检查定时任务
+
+面板 → **定时任务**，应能看到自动创建的任务，例如：
+
+- bili每日任务
+- bili扫码登录
+- bili银瓜子兑换硬币任务
+- ……
+
+如果没看到，去订阅的运行日志里看「执行订阅钩子 / 扫描脚本 / 自动添加任务」相关输出排查（一般是网络拉库失败、钩子没填、或白名单写错）。
+
+### 2.5. 扫码登录
+
+在「定时任务」里找到 **bili扫码登录**，点「运行」，查看运行日志，用手机 B 站 App 扫描日志里的二维码登录。
+
+- **首次运行会自动安装运行环境**（dotnet 或 bilitool），时间可能稍长，之后就不用重复装了。
+- 登录成功后，如果已按 [2.1](#21-新建-open-api-应用拿-appkey--appsecret) / [2.2](#22-配置环境变量) 配好 Open API，工具会通过面板原生 Open API 自动把 Cookie 写到环境变量 `Ray_BiliBiliCookies__0`（多账号依次 `__1`、`__2`……）。
+- 如果没配 Open API，工具会在日志里打印出 `变量Key` 和 `变量值`，**请手动**到面板「环境变量」里照着添加。
+
+之后各个每日任务会按 cron 自动运行，从环境变量读取 Cookie 执行。
+
+## 3. 运行模式：dotnet vs bilitool
+
+通过环境变量 `BILI_MODE` 切换：
+
+| 模式 | 说明 | Cookie 自动写回 |
+| --- | --- | --- |
+| `dotnet`（默认） | 在面板容器里安装 .NET 8 SDK，直接用 `dotnet run` **从本仓库源码编译运行** | ✅ 立即可用（源码里已包含呆呆面板适配） |
+| `bilitool` | 不装 dotnet，直接下载 GitHub 上预编译好的 `bilitool` 二进制运行，更轻量 | ⚠️ 需要等官方发布**包含呆呆面板适配的新版本**后才支持；旧版本二进制不认识 `DaiDai` 平台，登录只会把 Cookie 打印到日志，需手动添加 |
+
+建议：
+
+- 想要**登录自动写回 Cookie 现在就能用** → 用默认的 `dotnet` 模式（拉本仓库源码编译）。
+- 面板资源紧张、不想装 dotnet，且能接受首次手动填一次 Cookie（或等新版本二进制） → 用 `bilitool` 模式。
+
+## 4. 先行版（dev）
+
+`develop` 分支的 `bili_dev_task_*.sh` 是开发中的新功能脚本。默认白名单 `bili_task_` 不会匹配它们；如果想体验先行版，把订阅白名单改成：
+
+```
+白名单：bili_task_,bili_dev_task_
+```
+
+钩子脚本会一并把 `dev/bili_dev_task_*.sh` 复用过来，它们共用同一份 base（`dev/bili_dev_task_base.sh` 只是 source 了上一级的 `bili_task_base.sh`）。
+
+## 5. GitHub 加速
+
+拉库 / 下载慢时，可在订阅链接前加加速代理，例如：
+
+```
+https://gh-proxy.com/https://github.com/RayWangQvQ/BiliBiliToolPro.git
+```
+
+`bilitool` 模式下载二进制的加速，用环境变量 `BILI_GITHUB_PROXY`（如 `https://gh-proxy.com/`）。加速地址通常不稳定，请自行查找可用的。
+
+## 6. 常见问题
+
+### 6.1. 提示找不到 `bash` / 脚本无法运行
+
+本方案依赖 `bash`，请确保你用的是 **Linux 容器形态的呆呆面板**（Docker / Magisk）。纯 Windows 单机版不适用。
+
+### 6.2. dotnet 安装失败
+
+`dotnet` 模式首次运行会自动装 .NET 8 SDK。如果失败，可：
+
+1. 进面板容器手动按微软官方文档安装 dotnet；或
+2. 切换到 `bilitool` 模式（`BILI_MODE=bilitool`，不需要 dotnet）。
+
+### 6.3. Couldn't find a valid ICU package
+
+脚本已默认设置 `DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1` 规避该问题。如仍报错，可在面板环境变量里再显式加一条：
+
+```
+名称：DOTNET_SYSTEM_GLOBALIZATION_INVARIANT
+值：1
+```
+
+### 6.4. 登录成功但 Cookie 没有自动写回
+
+按以下顺序排查：
+
+1. 是否建了 Open API 应用，且**授权范围包含 `envs`**；
+2. 环境变量 `DaiDaiConfig__AppKey` / `DaiDaiConfig__AppSecret` 是否填对（双下划线 `__`）；
+3. `DaiDai_URL` 是否能从面板容器内访问到（默认 `http://127.0.0.1:5700`；改过端口或跨机部署要填实际地址）；
+4. 用的是不是 `bilitool` 模式且二进制版本过旧（见 [第 3 节](#3-运行模式dotnet-vs-bilitool)）。
+
+登录日志里会打印鉴权与写回的过程，按提示定位即可。失败时工具也会把 Cookie 打印出来，可先手动添加环境变量兜底。
+
+### 6.5. 任务没被自动创建
+
+去订阅的运行日志看：
+
+- 是否有 `[执行订阅钩子]` 且同步了脚本 → 没有就检查「钩子脚本」是否填了 `bash daidai/copyshfile.sh`；
+- 「扫描脚本…识别出 N 个含 cron 的脚本」→ 为 0 就检查白名单是否写成了 `bili_task_`、文件后缀是否含 `sh`；
+- 一个文件都没扫到 → 多半是拉库失败。

--- a/daidai/copyshfile.sh
+++ b/daidai/copyshfile.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+# 呆呆面板订阅「钩子脚本」：复用 qinglong 的各任务脚本，避免在 daidai 里重复维护。
+# 配置方式：在订阅的「钩子脚本」里填  bash daidai/copyshfile.sh
+# 运行时机：呆呆面板在“拉库之后、自动建任务之前”执行本钩子（CWD 即仓库目录）。
+#
+# 做的事：
+#   1. 把 qinglong/DefaultTasks 下的 bili_task_*.sh（base 除外）拷到 daidai/DefaultTasks；
+#   2. 把 qinglong/DefaultTasks/dev 下的 bili_dev_task_*.sh（base 除外）拷到 daidai/DefaultTasks/dev；
+#   3. 删除 qinglong 目录，避免青龙版脚本（依赖 /ql 路径）被面板误登记成任务。
+# 各任务脚本只是 `. bili_task_base.sh; run_task "Xxx"`，与面板无关，所以可直接复用；
+# 真正面板相关的“环境安装/定位”只在 daidai 自己的 bili_task_base.sh 里实现。
+
+set -e
+
+# 仓库根目录：优先用呆呆面板注入的 SUB_DIR，否则从脚本自身位置推算
+if [ -n "${SUB_DIR:-}" ]; then
+    REPO_ROOT="$SUB_DIR"
+else
+    CURRENT_FILE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    REPO_ROOT="$(dirname "$CURRENT_FILE_DIR")"
+fi
+
+SRC_ROOT="$REPO_ROOT/qinglong/DefaultTasks"
+DST_ROOT="$REPO_ROOT/daidai/DefaultTasks"
+
+if [ ! -d "$SRC_ROOT" ]; then
+    echo ">>> 未找到 $SRC_ROOT，跳过同步（可能已同步过）。"
+    exit 0
+fi
+
+mkdir -p "$DST_ROOT"
+
+echo ">>> 从 $SRC_ROOT 同步任务脚本到 $DST_ROOT ..."
+for file in "$SRC_ROOT"/bili_task_*.sh; do
+    [ -e "$file" ] || continue
+    filename=$(basename "$file")
+    # base 由 daidai 自己提供，不覆盖
+    [ "$filename" = "bili_task_base.sh" ] && continue
+    cp -f "$file" "$DST_ROOT/"
+    echo "已同步: $filename"
+done
+
+echo ">>> 从 $SRC_ROOT/dev 同步先行版任务脚本 ..."
+mkdir -p "$DST_ROOT/dev"
+for file in "$SRC_ROOT"/dev/bili_dev_task_*.sh; do
+    [ -e "$file" ] || continue
+    filename=$(basename "$file")
+    [ "$filename" = "bili_dev_task_base.sh" ] && continue
+    cp -f "$file" "$DST_ROOT/dev/"
+    echo "已同步: dev/$filename"
+done
+
+echo ">>> 清理 qinglong 目录，避免被重复登记成任务 ..."
+rm -rf "$REPO_ROOT/qinglong"
+
+echo ">>> 同步完成。"

--- a/src/Ray.BiliBiliTool.Agent/DaiDai/Dtos/DaiDaiEnv.cs
+++ b/src/Ray.BiliBiliTool.Agent/DaiDai/Dtos/DaiDaiEnv.cs
@@ -1,0 +1,24 @@
+using System.Text.Json.Serialization;
+
+namespace Ray.BiliBiliTool.Agent.DaiDai.Dtos;
+
+/// <summary>
+/// 呆呆面板环境变量实体（对应 /api/envs 返回与提交的 data 项）
+/// </summary>
+public class DaiDaiEnv
+{
+    [JsonPropertyName("id")]
+    public long Id { get; set; }
+
+    [JsonPropertyName("name")]
+    public string Name { get; set; }
+
+    [JsonPropertyName("value")]
+    public string Value { get; set; }
+
+    [JsonPropertyName("remarks")]
+    public string Remarks { get; set; }
+
+    [JsonPropertyName("enabled")]
+    public bool Enabled { get; set; }
+}

--- a/src/Ray.BiliBiliTool.Agent/DaiDai/Dtos/DaiDaiEnvResponse.cs
+++ b/src/Ray.BiliBiliTool.Agent/DaiDai/Dtos/DaiDaiEnvResponse.cs
@@ -1,0 +1,15 @@
+using System.Text.Json.Serialization;
+
+namespace Ray.BiliBiliTool.Agent.DaiDai.Dtos;
+
+/// <summary>
+/// POST/PUT /api/envs 的单条响应：{ "message": "...", "data": { ... } }
+/// </summary>
+public class DaiDaiEnvResponse
+{
+    [JsonPropertyName("message")]
+    public string Message { get; set; }
+
+    [JsonPropertyName("data")]
+    public DaiDaiEnv Data { get; set; }
+}

--- a/src/Ray.BiliBiliTool.Agent/DaiDai/Dtos/DaiDaiEnvsResponse.cs
+++ b/src/Ray.BiliBiliTool.Agent/DaiDai/Dtos/DaiDaiEnvsResponse.cs
@@ -1,0 +1,16 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace Ray.BiliBiliTool.Agent.DaiDai.Dtos;
+
+/// <summary>
+/// GET /api/envs 的分页响应：{ "data": [ ... ], "total": n, "page": 1, "page_size": 20 }
+/// </summary>
+public class DaiDaiEnvsResponse
+{
+    [JsonPropertyName("data")]
+    public List<DaiDaiEnv> Data { get; set; } = [];
+
+    [JsonPropertyName("total")]
+    public long Total { get; set; }
+}

--- a/src/Ray.BiliBiliTool.Agent/DaiDai/Dtos/DaiDaiTokenRequest.cs
+++ b/src/Ray.BiliBiliTool.Agent/DaiDai/Dtos/DaiDaiTokenRequest.cs
@@ -1,0 +1,15 @@
+using System.Text.Json.Serialization;
+
+namespace Ray.BiliBiliTool.Agent.DaiDai.Dtos;
+
+/// <summary>
+/// POST /api/open-api/token 的请求体
+/// </summary>
+public class DaiDaiTokenRequest
+{
+    [JsonPropertyName("app_key")]
+    public string AppKey { get; set; }
+
+    [JsonPropertyName("app_secret")]
+    public string AppSecret { get; set; }
+}

--- a/src/Ray.BiliBiliTool.Agent/DaiDai/Dtos/DaiDaiTokenResponse.cs
+++ b/src/Ray.BiliBiliTool.Agent/DaiDai/Dtos/DaiDaiTokenResponse.cs
@@ -1,0 +1,24 @@
+using System.Text.Json.Serialization;
+
+namespace Ray.BiliBiliTool.Agent.DaiDai.Dtos;
+
+/// <summary>
+/// POST /api/open-api/token 的响应：{ "data": { access_token, token_type, expires_in } }
+/// </summary>
+public class DaiDaiTokenResponse
+{
+    [JsonPropertyName("data")]
+    public DaiDaiTokenData Data { get; set; }
+}
+
+public class DaiDaiTokenData
+{
+    [JsonPropertyName("access_token")]
+    public string AccessToken { get; set; }
+
+    [JsonPropertyName("token_type")]
+    public string TokenType { get; set; }
+
+    [JsonPropertyName("expires_in")]
+    public long ExpiresIn { get; set; }
+}

--- a/src/Ray.BiliBiliTool.Agent/DaiDai/IDaiDaiApi.cs
+++ b/src/Ray.BiliBiliTool.Agent/DaiDai/IDaiDaiApi.cs
@@ -1,0 +1,32 @@
+using Ray.BiliBiliTool.Agent.DaiDai.Dtos;
+using Refit;
+
+namespace Ray.BiliBiliTool.Agent.DaiDai;
+
+/// <summary>
+/// 呆呆面板（Daidai Panel）原生 Open API。
+/// 鉴权流程：先用 AppKey/AppSecret 换 access_token，再带 Authorization: Bearer {token}
+/// 调用环境变量接口（面板里新建的 Open API 应用需具备 envs 授权范围）。
+/// </summary>
+public interface IDaiDaiApi
+{
+    [Post("/api/open-api/token")]
+    Task<DaiDaiTokenResponse> GetTokenAsync([Body] DaiDaiTokenRequest request);
+
+    [Get("/api/envs")]
+    Task<DaiDaiEnvsResponse> GetEnvsAsync(
+        string keyword,
+        string all,
+        [Header("Authorization")] string token
+    );
+
+    [Post("/api/envs")]
+    Task<DaiDaiEnvResponse> AddEnvAsync([Body] DaiDaiEnv env, [Header("Authorization")] string token);
+
+    [Put("/api/envs/{id}")]
+    Task<DaiDaiEnvResponse> UpdateEnvAsync(
+        long id,
+        [Body] DaiDaiEnv env,
+        [Header("Authorization")] string token
+    );
+}

--- a/src/Ray.BiliBiliTool.Agent/Extensions/ServiceCollectionExtension.cs
+++ b/src/Ray.BiliBiliTool.Agent/Extensions/ServiceCollectionExtension.cs
@@ -10,6 +10,7 @@ using Ray.BiliBiliTool.Agent.BiliBiliAgent.Services;
 using Ray.BiliBiliTool.Agent.HttpClientDelegatingHandlers;
 using Ray.BiliBiliTool.Agent.QingLong;
 using Ray.BiliBiliTool.Agent.Baihu;
+using Ray.BiliBiliTool.Agent.DaiDai;
 using Ray.BiliBiliTool.Config.Options;
 using Ray.BiliBiliTool.Infrastructure.Cookie;
 using Refit;
@@ -110,6 +111,24 @@ public static class ServiceCollectionExtension
                 (sp, c) =>
                 {
                     c.BaseAddress = new Uri(baihuHost);
+                    c.DefaultRequestHeaders.Add(
+                        "User-Agent",
+                        sp.GetRequiredService<
+                            IOptionsMonitor<SecurityOptions>
+                        >().CurrentValue.UserAgent
+                    );
+                }
+            )
+            .AddPolicyHandler(BiliResiliencePolicies.ReadOnlyPolicy());
+
+        //daidai（呆呆面板原生 Open API）
+        var daidaiHost = configuration["DaiDai_URL"] ?? "http://127.0.0.1:5700";
+        services
+            .AddRefitClient<IDaiDaiApi>()
+            .ConfigureHttpClient(
+                (sp, c) =>
+                {
+                    c.BaseAddress = new Uri(daidaiHost);
                     c.DefaultRequestHeaders.Add(
                         "User-Agent",
                         sp.GetRequiredService<

--- a/src/Ray.BiliBiliTool.Application/BaseMultiAccountsAppService.cs
+++ b/src/Ray.BiliBiliTool.Application/BaseMultiAccountsAppService.cs
@@ -80,6 +80,13 @@ public abstract class BaseMultiAccountsAppService(
             return;
         }
 
+        //更新cookie到呆呆面板env
+        if (platformType == PlatformType.DaiDai)
+        {
+            await loginDomainService.SaveCookieToDaiDaiAsync(ckInfo, cancellationToken);
+            return;
+        }
+
         await loginDomainService.SaveCookieToJsonFileAsync(ckInfo, cancellationToken);
     }
 }

--- a/src/Ray.BiliBiliTool.Application/LoginTaskAppService.cs
+++ b/src/Ray.BiliBiliTool.Application/LoginTaskAppService.cs
@@ -117,6 +117,13 @@ public class LoginTaskAppService(
             return;
         }
 
+        //更新cookie到呆呆面板env
+        if (platformType == PlatformType.DaiDai)
+        {
+            await loginDomainService.SaveCookieToDaiDaiAsync(ckInfo, cancellationToken);
+            return;
+        }
+
         //更新cookie到json
         await loginDomainService.SaveCookieToJsonFileAsync(ckInfo, cancellationToken);
     }

--- a/src/Ray.BiliBiliTool.Config/Extensions/ServiceCollectionExtension.cs
+++ b/src/Ray.BiliBiliTool.Config/Extensions/ServiceCollectionExtension.cs
@@ -41,7 +41,8 @@ public static class ServiceCollectionExtension
                 configuration.GetSection("LiveFansMedalTaskConfig")
             )
             .Configure<QingLongOptions>(configuration.GetSection("QingLongConfig"))
-            .Configure<BaihuOptions>(configuration.GetSection("BaihuConfig"));
+            .Configure<BaihuOptions>(configuration.GetSection("BaihuConfig"))
+            .Configure<DaiDaiOptions>(configuration.GetSection("DaiDaiConfig"));
 
         return services;
     }

--- a/src/Ray.BiliBiliTool.Config/Options/DaiDaiOptions.cs
+++ b/src/Ray.BiliBiliTool.Config/Options/DaiDaiOptions.cs
@@ -1,0 +1,14 @@
+namespace Ray.BiliBiliTool.Config.Options;
+
+/// <summary>
+/// 呆呆面板（Daidai Panel）Open API 配置。
+/// 在面板「系统设置 -> Open API」新建应用（授权范围至少含 envs），
+/// 拿到 AppKey / AppSecret 后配置到环境变量 DaiDaiConfig__AppKey、DaiDaiConfig__AppSecret，
+/// 面板地址通过环境变量 DaiDai_URL 配置（默认 http://127.0.0.1:5700）。
+/// </summary>
+public class DaiDaiOptions
+{
+    public string AppKey { get; set; } = "";
+
+    public string AppSecret { get; set; } = "";
+}

--- a/src/Ray.BiliBiliTool.DomainService/Interfaces/ILoginDomainService.cs
+++ b/src/Ray.BiliBiliTool.DomainService/Interfaces/ILoginDomainService.cs
@@ -56,4 +56,12 @@ public interface ILoginDomainService : IDomainService
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
     Task<bool> SaveCookieToBaihuAsync(BiliCookie ckInfo, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// 持久化Cookie到呆呆面板环境变量（通过其原生 Open API）
+    /// </summary>
+    /// <param name="ckInfo"></param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    Task<bool> SaveCookieToDaiDaiAsync(BiliCookie ckInfo, CancellationToken cancellationToken);
 }

--- a/src/Ray.BiliBiliTool.DomainService/LoginDomainService.cs
+++ b/src/Ray.BiliBiliTool.DomainService/LoginDomainService.cs
@@ -13,6 +13,8 @@ using Ray.BiliBiliTool.Agent.QingLong;
 using Ray.BiliBiliTool.Agent.QingLong.Dtos;
 using Ray.BiliBiliTool.Agent.Baihu;
 using Ray.BiliBiliTool.Agent.Baihu.Dtos;
+using Ray.BiliBiliTool.Agent.DaiDai;
+using Ray.BiliBiliTool.Agent.DaiDai.Dtos;
 using Ray.BiliBiliTool.Config.Options;
 using Ray.BiliBiliTool.Domain.Exceptions;
 using Ray.BiliBiliTool.DomainService.Dtos;
@@ -30,10 +32,12 @@ public class LoginDomainService(
     IHostEnvironment hostingEnvironment,
     IQingLongApi qingLongApi,
     IBaihuApi baihuApi,
+    IDaiDaiApi daiDaiApi,
     IHomeApi homeApi,
     IConfiguration configuration,
     IOptions<QingLongOptions> qingLongOptions,
-    IOptions<BaihuOptions> baihuOptions
+    IOptions<BaihuOptions> baihuOptions,
+    IOptions<DaiDaiOptions> daiDaiOptions
 ) : ILoginDomainService
 {
     public async Task<BiliCookie> LoginByQrCodeAsync(CancellationToken cancellationToken)
@@ -477,6 +481,81 @@ public class LoginDomainService(
         }
     }
 
+    public async Task<bool> SaveCookieToDaiDaiAsync(
+        BiliCookie ckInfo,
+        CancellationToken cancellationToken
+    )
+    {
+        try
+        {
+            // 先用 AppKey/AppSecret 换取 access_token
+            var token = await GetDaiDaiAuthTokenAsync();
+            if (string.IsNullOrEmpty(token))
+            {
+                throw new Exception("获取呆呆面板token失败");
+            }
+
+            // all=1 返回全部匹配项，避免分页漏掉
+            var envListRe = await daiDaiApi.GetEnvsAsync("Ray_BiliBiliCookies__", "1", token);
+
+            var list = (envListRe.Data ?? [])
+                .Where(x => x.Name != null && x.Name.StartsWith("Ray_BiliBiliCookies__"))
+                .ToList();
+            var oldEnv = list.FirstOrDefault(x =>
+                x.Value != null && x.Value.Contains(ckInfo.UserId)
+            );
+
+            if (oldEnv != null)
+            {
+                logger.LogInformation("用户已存在，更新呆呆面板环境变量");
+                logger.LogInformation("Key：{key}", oldEnv.Name);
+
+                oldEnv.Value = ckInfo.CookieStr;
+                oldEnv.Remarks = string.IsNullOrEmpty(oldEnv.Remarks)
+                    ? $"bili-{ckInfo.UserId}"
+                    : oldEnv.Remarks;
+
+                var updateRe = await daiDaiApi.UpdateEnvAsync(oldEnv.Id, oldEnv, token);
+                logger.LogInformation("更新成功！{msg}", updateRe.Message);
+
+                return true;
+            }
+
+            logger.LogInformation("用户不存在，新增呆呆面板环境变量");
+            var maxNum = -1;
+            if (list.Any())
+            {
+                maxNum = list.Select(x =>
+                    {
+                        var num = (x.Name ?? "").Replace("Ray_BiliBiliCookies__", "");
+                        var parseSuc = int.TryParse(num, out int envNum);
+                        return parseSuc ? envNum : 0;
+                    })
+                    .Max();
+            }
+
+            var name = $"Ray_BiliBiliCookies__{maxNum + 1}";
+            logger.LogInformation("Key：{key}", name);
+
+            var add = new DaiDaiEnv
+            {
+                Name = name,
+                Value = ckInfo.CookieStr,
+                Remarks = $"bili-{ckInfo.UserId}",
+                Enabled = true,
+            };
+            var addRe = await daiDaiApi.AddEnvAsync(add, token);
+            logger.LogInformation("新增成功！{msg}", addRe.Message);
+            return true;
+        }
+        catch (Exception e)
+        {
+            logger.LogError("保存到呆呆面板失败：{msg}", e.Message);
+            await PrintIfSaveCookieFailAsync(ckInfo, cancellationToken);
+            return false;
+        }
+    }
+
     #region private
 
     private void GenerateQrCode(string str)
@@ -598,15 +677,56 @@ public class LoginDomainService(
         return $"{token.Data.token_type} {token.Data.token}";
     }
 
+    private async Task<string> GetDaiDaiAuthTokenAsync()
+    {
+        logger.LogWarning("使用呆呆面板OpenAPI鉴权");
+        if (
+            string.IsNullOrWhiteSpace(daiDaiOptions.Value.AppKey)
+            || string.IsNullOrWhiteSpace(daiDaiOptions.Value.AppSecret)
+        )
+        {
+            logger.LogWarning("未配置呆呆面板的AppKey和AppSecret，无法自动获取token");
+            logger.LogWarning(
+                "教程：{daidaiDoc}",
+                "https://github.com/RayWangQvQ/BiliBiliToolPro/blob/develop/daidai/README.md"
+            );
+            return "";
+        }
+
+        var re = await daiDaiApi.GetTokenAsync(
+            new DaiDaiTokenRequest
+            {
+                AppKey = daiDaiOptions.Value.AppKey,
+                AppSecret = daiDaiOptions.Value.AppSecret,
+            }
+        );
+
+        if (re.Data == null || string.IsNullOrEmpty(re.Data.AccessToken))
+        {
+            return "";
+        }
+
+        return $"{re.Data.TokenType} {re.Data.AccessToken}";
+    }
+
     private Task PrintIfSaveCookieFailAsync(BiliCookie ckInfo, CancellationToken cancellationToken)
     {
         var platform = configuration["Ray_PlatformType"] ?? "";
-        var platformName = platform.Equals("Baihu", StringComparison.OrdinalIgnoreCase) ? "白虎" : "青龙";
+        var platformName = platform.Equals("Baihu", StringComparison.OrdinalIgnoreCase)
+            ? "白虎"
+            : platform.Equals("DaiDai", StringComparison.OrdinalIgnoreCase)
+                ? "呆呆"
+                : "青龙";
 
         if (platformName == "白虎")
         {
             logger.LogError("持久化失败，请手动添加环境变量到白虎面板");
             logger.LogInformation("提示：配置环境变量 BaihuConfig__Token 后，在baihu面板系统设置->openapi获取，程序可尝试自动保存。");
+        }
+        else if (platformName == "呆呆")
+        {
+            logger.LogError("持久化失败，请手动添加环境变量到呆呆面板");
+            logger.LogInformation("提示：在呆呆面板「系统设置->Open API」新建应用（授权范围含 envs），配置环境变量 DaiDaiConfig__AppKey / DaiDaiConfig__AppSecret 后，程序可尝试自动保存。");
         }
         else
         {

--- a/src/Ray.BiliBiliTool.Infrastructure/Enums/PlatformType.cs
+++ b/src/Ray.BiliBiliTool.Infrastructure/Enums/PlatformType.cs
@@ -8,4 +8,5 @@ public enum PlatformType
     QingLong,
     Web,
     Baihu,
+    DaiDai,
 }

--- a/test/Ray.BiliBiliTool.CharacterizationTests/DailyTaskCharacterizationTests.cs
+++ b/test/Ray.BiliBiliTool.CharacterizationTests/DailyTaskCharacterizationTests.cs
@@ -371,6 +371,14 @@ public class DailyTaskCharacterizationTests
             throw new NotSupportedException();
         }
 
+        public Task<bool> SaveCookieToDaiDaiAsync(
+            BiliCookie ckInfo,
+            CancellationToken cancellationToken
+        )
+        {
+            throw new NotSupportedException();
+        }
+
         public Task<QrLoginGenerateResult> GenerateQrCodeWebAsync(
             CancellationToken cancellationToken
         )

--- a/test/Ray.BiliBiliTool.CharacterizationTests/LoginTaskCharacterizationTests.cs
+++ b/test/Ray.BiliBiliTool.CharacterizationTests/LoginTaskCharacterizationTests.cs
@@ -110,6 +110,14 @@ public class LoginTaskCharacterizationTests
             throw new NotSupportedException();
         }
 
+        public Task<bool> SaveCookieToDaiDaiAsync(
+            BiliCookie ckInfo,
+            CancellationToken cancellationToken
+        )
+        {
+            throw new NotSupportedException();
+        }
+
         public Task<QrLoginGenerateResult> GenerateQrCodeWebAsync(
             CancellationToken cancellationToken
         )


### PR DESCRIPTION
## 适配呆呆面板（Daidai Panel）

[呆呆面板](https://github.com/linzixuanzz/daidai-panel) 是一款 Go + Vue + SQLite 的轻量定时任务面板（issue #1066 提到）。本 PR 新增在呆呆面板中运行 BiliBiliToolPro 的支持。我是呆呆面板的作者，想把适配回馈到上游，方便两边用户。

### 做法：对齐已合并的 baihu/ 集成，复用青龙脚本
参考你在 baihu PR 里的建议（各任务脚本与青龙一致应复用、只有环境安装部分各面板自己实现）：
- `daidai/` 只保留一份面板专属 `bili_task_base.sh`（环境安装/定位）；
- 各任务脚本由订阅钩子 `daidai/copyshfile.sh` 在拉库后从 `qinglong/DefaultTasks` 复用，并清理 qinglong 目录；
- stable 与 dev 共用同一份 base（base 用 `Ray.BiliBiliTool.sln` 向上定位仓库根，dev base 仅 source 上一级），比 baihu 再少一层重复。

### Cookie 自动写回
登录后通过呆呆面板**原生 Open API**（`POST /api/open-api/token` 换 token → `/api/envs` upsert）把 Cookie 写回面板环境变量，`Ray_PlatformType=DaiDai`。C# 侧参照已合并的 Baihu（Refit）实现 `IDaiDaiApi` / `SaveCookieToDaiDaiAsync`，并接入两处持久化分发点（LoginTaskAppService、BaseMultiAccountsAppService）。

### 验证
- `dotnet build` 全绿；CharacterizationTests 通过
- 本地起呆呆面板实例，用真实 Refit 客户端跑通 token + 环境变量增改查
- `copyshfile.sh` / 仓库根定位均已实跑验证

详见 `daidai/README.md`。closes #1066